### PR TITLE
Add ABCI methods for Fraud Proof Generation

### DIFF
--- a/abci/client/client.go
+++ b/abci/client/client.go
@@ -56,6 +56,9 @@ type Client interface {
 	OfferSnapshotSync(types.RequestOfferSnapshot) (*types.ResponseOfferSnapshot, error)
 	LoadSnapshotChunkSync(types.RequestLoadSnapshotChunk) (*types.ResponseLoadSnapshotChunk, error)
 	ApplySnapshotChunkSync(types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error)
+	GetAppHashSync(types.RequestGetAppHash) (*types.ResponseGetAppHash, error)
+	GenerateFraudProofSync(types.RequestGenerateFraudProof) (*types.ResponseGenerateFraudProof, error)
+	TriggerFraudProofGenerationModeSync(types.RequestTriggerFraudProofGenerationMode) (*types.ResponseTriggerFraudProofGenerationMode, error)
 }
 
 //----------------------------------------

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -302,6 +302,33 @@ func (cli *grpcClient) ApplySnapshotChunkAsync(params types.RequestApplySnapshot
 	return cli.finishAsyncCall(req, &types.Response{Value: &types.Response_ApplySnapshotChunk{ApplySnapshotChunk: res}})
 }
 
+func (cli *grpcClient) GetAppHashAsync(params types.RequestGetAppHash) *ReqRes {
+	req := types.ToRequestGetAppHash(params)
+	res, err := cli.client.GetAppHash(context.Background(), req.GetGetAppHash(), grpc.WaitForReady(true))
+	if err != nil {
+		cli.StopForError(err)
+	}
+	return cli.finishAsyncCall(req, &types.Response{Value: &types.Response_GetAppHash{GetAppHash: res}})
+}
+
+func (cli *grpcClient) GenerateFraudProofAsync(params types.RequestGenerateFraudProof) *ReqRes {
+	req := types.ToRequestGenerateFraudProof(params)
+	res, err := cli.client.GenerateFraudProof(context.Background(), req.GetGenerateFraudProof(), grpc.WaitForReady(true))
+	if err != nil {
+		cli.StopForError(err)
+	}
+	return cli.finishAsyncCall(req, &types.Response{Value: &types.Response_GenerateFraudProof{GenerateFraudProof: res}})
+}
+
+func (cli *grpcClient) TriggerFraudProofGenerationModeAsync(params types.RequestTriggerFraudProofGenerationMode) *ReqRes {
+	req := types.ToRequestTriggerFraudProofGenerationMode(params)
+	res, err := cli.client.TriggerFraudProofGenerationMode(context.Background(), req.GetTriggerFraudProofGenerationMode(), grpc.WaitForReady(true))
+	if err != nil {
+		cli.StopForError(err)
+	}
+	return cli.finishAsyncCall(req, &types.Response{Value: &types.Response_TriggerFraudProofGenerationMode{TriggerFraudProofGenerationMode: res}})
+}
+
 // finishAsyncCall creates a ReqRes for an async call, and immediately populates it
 // with the response. We don't complete it until it's been ordered via the channel.
 func (cli *grpcClient) finishAsyncCall(req *types.Request, res *types.Response) *ReqRes {
@@ -416,4 +443,22 @@ func (cli *grpcClient) ApplySnapshotChunkSync(
 	params types.RequestApplySnapshotChunk) (*types.ResponseApplySnapshotChunk, error) {
 	reqres := cli.ApplySnapshotChunkAsync(params)
 	return cli.finishSyncCall(reqres).GetApplySnapshotChunk(), cli.Error()
+}
+
+func (cli *grpcClient) GetAppHashSync(
+	params types.RequestGetAppHash) (*types.ResponseGetAppHash, error) {
+	reqres := cli.GetAppHashAsync(params)
+	return cli.finishSyncCall(reqres).GetGetAppHash(), cli.Error()
+}
+
+func (cli *grpcClient) GenerateFraudProofSync(
+	params types.RequestGenerateFraudProof) (*types.ResponseGenerateFraudProof, error) {
+	reqres := cli.GenerateFraudProofAsync(params)
+	return cli.finishSyncCall(reqres).GetGenerateFraudProof(), cli.Error()
+}
+
+func (cli *grpcClient) TriggerFraudProofGenerationModeSync(
+	params types.RequestTriggerFraudProofGenerationMode) (*types.ResponseTriggerFraudProofGenerationMode, error) {
+	reqres := cli.TriggerFraudProofGenerationModeAsync(params)
+	return cli.finishSyncCall(reqres).GetTriggerFraudProofGenerationMode(), cli.Error()
 }

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -207,6 +207,39 @@ func (app *localClient) ApplySnapshotChunkAsync(req types.RequestApplySnapshotCh
 	)
 }
 
+func (app *localClient) GetAppHashAsync(req types.RequestGetAppHash) *ReqRes {
+	app.mtx.Lock()
+	defer app.mtx.Unlock()
+
+	res := app.Application.GetAppHash(req)
+	return app.callback(
+		types.ToRequestGetAppHash(req),
+		types.ToResponseGetAppHash(res),
+	)
+}
+
+func (app *localClient) GenerateFraudProofAsync(req types.RequestGenerateFraudProof) *ReqRes {
+	app.mtx.Lock()
+	defer app.mtx.Unlock()
+
+	res := app.Application.GenerateFraudProof(req)
+	return app.callback(
+		types.ToRequestGenerateFraudProof(req),
+		types.ToResponseGenerateFraudProof(res),
+	)
+}
+
+func (app *localClient) TriggerFraudProofGenerationModeAsync(req types.RequestTriggerFraudProofGenerationMode) *ReqRes {
+	app.mtx.Lock()
+	defer app.mtx.Unlock()
+
+	res := app.Application.TriggerFraudProofGenerationMode(req)
+	return app.callback(
+		types.ToRequestTriggerFraudProofGenerationMode(req),
+		types.ToResponseTriggerFraudProofGenerationMode(res),
+	)
+}
+
 //-------------------------------------------------------
 
 func (app *localClient) FlushSync() error {
@@ -320,6 +353,33 @@ func (app *localClient) ApplySnapshotChunkSync(
 	defer app.mtx.Unlock()
 
 	res := app.Application.ApplySnapshotChunk(req)
+	return &res, nil
+}
+
+func (app *localClient) GetAppHashSync(
+	req types.RequestGetAppHash) (*types.ResponseGetAppHash, error) {
+	app.mtx.Lock()
+	defer app.mtx.Unlock()
+
+	res := app.Application.GetAppHash(req)
+	return &res, nil
+}
+
+func (app *localClient) GenerateFraudProofSync(
+	req types.RequestGenerateFraudProof) (*types.ResponseGenerateFraudProof, error) {
+	app.mtx.Lock()
+	defer app.mtx.Unlock()
+
+	res := app.Application.GenerateFraudProof(req)
+	return &res, nil
+}
+
+func (app *localClient) TriggerFraudProofGenerationModeSync(
+	req types.RequestTriggerFraudProofGenerationMode) (*types.ResponseTriggerFraudProofGenerationMode, error) {
+	app.mtx.Lock()
+	defer app.mtx.Unlock()
+
+	res := app.Application.TriggerFraudProofGenerationMode(req)
 	return &res, nil
 }
 

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -279,6 +279,18 @@ func (cli *socketClient) ApplySnapshotChunkAsync(req types.RequestApplySnapshotC
 	return cli.queueRequest(types.ToRequestApplySnapshotChunk(req))
 }
 
+func (cli *socketClient) GetAppHashAsync(req types.RequestGetAppHash) *ReqRes {
+	return cli.queueRequest(types.ToRequestGetAppHash(req))
+}
+
+func (cli *socketClient) GenerateFraudProofAsync(req types.RequestGenerateFraudProof) *ReqRes {
+	return cli.queueRequest(types.ToRequestGenerateFraudProof(req))
+}
+
+func (cli *socketClient) TriggerFraudProofGenerationModeAsync(req types.RequestTriggerFraudProofGenerationMode) *ReqRes {
+	return cli.queueRequest(types.ToRequestTriggerFraudProofGenerationMode(req))
+}
+
 //----------------------------------------
 
 func (cli *socketClient) FlushSync() error {
@@ -415,6 +427,33 @@ func (cli *socketClient) ApplySnapshotChunkSync(
 		return nil, err
 	}
 	return reqres.Response.GetApplySnapshotChunk(), cli.Error()
+}
+
+func (cli *socketClient) GetAppHashSync(
+	req types.RequestGetAppHash) (*types.ResponseGetAppHash, error) {
+	reqres := cli.queueRequest(types.ToRequestGetAppHash(req))
+	if err := cli.FlushSync(); err != nil {
+		return nil, err
+	}
+	return reqres.Response.GetGetAppHash(), cli.Error()
+}
+
+func (cli *socketClient) GenerateFraudProofSync(
+	req types.RequestGenerateFraudProof) (*types.ResponseGenerateFraudProof, error) {
+	reqres := cli.queueRequest(types.ToRequestGenerateFraudProof(req))
+	if err := cli.FlushSync(); err != nil {
+		return nil, err
+	}
+	return reqres.Response.GetGenerateFraudProof(), cli.Error()
+}
+
+func (cli *socketClient) TriggerFraudProofGenerationModeSync(
+	req types.RequestTriggerFraudProofGenerationMode) (*types.ResponseTriggerFraudProofGenerationMode, error) {
+	reqres := cli.queueRequest(types.ToRequestTriggerFraudProofGenerationMode(req))
+	if err := cli.FlushSync(); err != nil {
+		return nil, err
+	}
+	return reqres.Response.GetTriggerFraudProofGenerationMode(), cli.Error()
 }
 
 //----------------------------------------

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -170,6 +170,21 @@ func (app *PersistentKVStoreApplication) ApplySnapshotChunk(
 	return types.ResponseApplySnapshotChunk{Result: types.ResponseApplySnapshotChunk_ABORT}
 }
 
+func (app *PersistentKVStoreApplication) GetAppHash(
+	req types.RequestGetAppHash) types.ResponseGetAppHash {
+	return types.ResponseGetAppHash{}
+}
+
+func (app *PersistentKVStoreApplication) GenerateFraudProof(
+	req types.RequestGenerateFraudProof) types.ResponseGenerateFraudProof {
+	return types.ResponseGenerateFraudProof{}
+}
+
+func (app *PersistentKVStoreApplication) TriggerFraudProofGenerationMode(
+	req types.RequestTriggerFraudProofGenerationMode) types.ResponseTriggerFraudProofGenerationMode {
+	return types.ResponseTriggerFraudProofGenerationMode{}
+}
+
 //---------------------------------------------
 // update validators
 

--- a/abci/server/socket_server.go
+++ b/abci/server/socket_server.go
@@ -236,6 +236,15 @@ func (s *SocketServer) handleRequest(req *types.Request, responses chan<- *types
 	case *types.Request_ApplySnapshotChunk:
 		res := s.app.ApplySnapshotChunk(*r.ApplySnapshotChunk)
 		responses <- types.ToResponseApplySnapshotChunk(res)
+	case *types.Request_GetAppHash:
+		res := s.app.GetAppHash(*r.GetAppHash)
+		responses <- types.ToResponseGetAppHash(res)
+	case *types.Request_GenerateFraudProof:
+		res := s.app.GenerateFraudProof(*r.GenerateFraudProof)
+		responses <- types.ToResponseGenerateFraudProof(res)
+	case *types.Request_TriggerFraudProofGenerationMode:
+		res := s.app.TriggerFraudProofGenerationMode(*r.TriggerFraudProofGenerationMode)
+		responses <- types.ToResponseGenerateFraudProof(res)
 	default:
 		responses <- types.ToResponseException("Unknown request")
 	}

--- a/abci/types/application.go
+++ b/abci/types/application.go
@@ -18,11 +18,14 @@ type Application interface {
 	CheckTx(RequestCheckTx) ResponseCheckTx // Validate a tx for the mempool
 
 	// Consensus Connection
-	InitChain(RequestInitChain) ResponseInitChain    // Initialize blockchain w validators/other info from TendermintCore
-	BeginBlock(RequestBeginBlock) ResponseBeginBlock // Signals the beginning of a block
-	DeliverTx(RequestDeliverTx) ResponseDeliverTx    // Deliver a tx for full processing
-	EndBlock(RequestEndBlock) ResponseEndBlock       // Signals the end of a block, returns changes to the validator set
-	Commit() ResponseCommit                          // Commit the state and return the application Merkle root hash
+	InitChain(RequestInitChain) ResponseInitChain                                                                   // Initialize blockchain w validators/other info from TendermintCore
+	BeginBlock(RequestBeginBlock) ResponseBeginBlock                                                                // Signals the beginning of a block
+	DeliverTx(RequestDeliverTx) ResponseDeliverTx                                                                   // Deliver a tx for full processing
+	EndBlock(RequestEndBlock) ResponseEndBlock                                                                      // Signals the end of a block, returns changes to the validator set
+	Commit() ResponseCommit                                                                                         // Commit the state and return the application Merkle root hash
+	GetAppHash(RequestGetAppHash) ResponseGetAppHash                                                                // Get appHash
+	GenerateFraudProof(RequestGenerateFraudProof) ResponseGenerateFraudProof                                        // Generate FraudProof
+	TriggerFraudProofGenerationMode(RequestTriggerFraudProofGenerationMode) ResponseTriggerFraudProofGenerationMode // Trigger Fraud Proof Generation Mode
 
 	// State Sync Connection
 	ListSnapshots(RequestListSnapshots) ResponseListSnapshots                // List available snapshots
@@ -93,6 +96,18 @@ func (BaseApplication) LoadSnapshotChunk(req RequestLoadSnapshotChunk) ResponseL
 
 func (BaseApplication) ApplySnapshotChunk(req RequestApplySnapshotChunk) ResponseApplySnapshotChunk {
 	return ResponseApplySnapshotChunk{}
+}
+
+func (BaseApplication) GetAppHash(req RequestGetAppHash) ResponseGetAppHash {
+	return ResponseGetAppHash{}
+}
+
+func (BaseApplication) GenerateFraudProof(req RequestGenerateFraudProof) ResponseGenerateFraudProof {
+	return ResponseGenerateFraudProof{}
+}
+
+func (BaseApplication) TriggerFraudProofGenerationMode(req RequestTriggerFraudProofGenerationMode) ResponseTriggerFraudProofGenerationMode {
+	return ResponseTriggerFraudProofGenerationMode{}
 }
 
 //-------------------------------------------------------
@@ -180,5 +195,23 @@ func (app *GRPCApplication) LoadSnapshotChunk(
 func (app *GRPCApplication) ApplySnapshotChunk(
 	ctx context.Context, req *RequestApplySnapshotChunk) (*ResponseApplySnapshotChunk, error) {
 	res := app.app.ApplySnapshotChunk(*req)
+	return &res, nil
+}
+
+func (app *GRPCApplication) GetAppHash(
+	ctx context.Context, req *RequestGetAppHash) (*ResponseGetAppHash, error) {
+	res := app.app.GetAppHash(*req)
+	return &res, nil
+}
+
+func (app *GRPCApplication) GenerateFraudProof(
+	ctx context.Context, req *RequestGenerateFraudProof) (*ResponseGenerateFraudProof, error) {
+	res := app.app.GenerateFraudProof(*req)
+	return &res, nil
+}
+
+func (app *GRPCApplication) TriggerFraudProofGenerationMode(
+	ctx context.Context, req *RequestTriggerFraudProofGenerationMode) (*ResponseTriggerFraudProofGenerationMode, error) {
+	res := app.app.TriggerFraudProofGenerationMode(*req)
 	return &res, nil
 }

--- a/abci/types/messages.go
+++ b/abci/types/messages.go
@@ -159,6 +159,24 @@ func ToRequestApplySnapshotChunk(req RequestApplySnapshotChunk) *Request {
 	}
 }
 
+func ToRequestGetAppHash(req RequestGetAppHash) *Request {
+	return &Request{
+		Value: &Request_GetAppHash{&req},
+	}
+}
+
+func ToRequestGenerateFraudProof(req RequestGenerateFraudProof) *Request {
+	return &Request{
+		Value: &Request_GenerateFraudProof{&req},
+	}
+}
+
+func ToRequestTriggerFraudProofGenerationMode(req RequestTriggerFraudProofGenerationMode) *Request {
+	return &Request{
+		Value: &Request_TriggerFraudProofGenerationMode{&req},
+	}
+}
+
 //----------------------------------------
 
 func ToResponseException(errStr string) *Response {
@@ -254,5 +272,23 @@ func ToResponseLoadSnapshotChunk(res ResponseLoadSnapshotChunk) *Response {
 func ToResponseApplySnapshotChunk(res ResponseApplySnapshotChunk) *Response {
 	return &Response{
 		Value: &Response_ApplySnapshotChunk{&res},
+	}
+}
+
+func ToResponseGetAppHash(res ResponseGetAppHash) *Response {
+	return &Response{
+		Value: &Response_GetAppHash{&res},
+	}
+}
+
+func ToResponseGenerateFraudProof(res ResponseGenerateFraudProof) *Response {
+	return &Response{
+		Value: &Response_GenerateFraudProof{&res},
+	}
+}
+
+func ToResponseTriggerFraudProofGenerationMode(res ResponseTriggerFraudProofGenerationMode) *Response {
+	return &Response{
+		Value: &Response_TriggerFraudProofGenerationMode{&res},
 	}
 }

--- a/abci/types/types.pb.go
+++ b/abci/types/types.pb.go
@@ -120,7 +120,7 @@ func (x ResponseOfferSnapshot_Result) String() string {
 }
 
 func (ResponseOfferSnapshot_Result) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{30, 0}
+	return fileDescriptor_252557cfdd89a31a, []int{33, 0}
 }
 
 type ResponseApplySnapshotChunk_Result int32
@@ -157,7 +157,7 @@ func (x ResponseApplySnapshotChunk_Result) String() string {
 }
 
 func (ResponseApplySnapshotChunk_Result) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{32, 0}
+	return fileDescriptor_252557cfdd89a31a, []int{35, 0}
 }
 
 type Request struct {
@@ -177,6 +177,9 @@ type Request struct {
 	//	*Request_OfferSnapshot
 	//	*Request_LoadSnapshotChunk
 	//	*Request_ApplySnapshotChunk
+	//	*Request_GetAppHash
+	//	*Request_GenerateFraudProof
+	//	*Request_TriggerFraudProofGenerationMode
 	Value isRequest_Value `protobuf_oneof:"value"`
 }
 
@@ -264,22 +267,34 @@ type Request_LoadSnapshotChunk struct {
 type Request_ApplySnapshotChunk struct {
 	ApplySnapshotChunk *RequestApplySnapshotChunk `protobuf:"bytes,15,opt,name=apply_snapshot_chunk,json=applySnapshotChunk,proto3,oneof" json:"apply_snapshot_chunk,omitempty"`
 }
+type Request_GetAppHash struct {
+	GetAppHash *RequestGetAppHash `protobuf:"bytes,16,opt,name=get_app_hash,json=getAppHash,proto3,oneof" json:"get_app_hash,omitempty"`
+}
+type Request_GenerateFraudProof struct {
+	GenerateFraudProof *RequestGenerateFraudProof `protobuf:"bytes,17,opt,name=generate_fraud_proof,json=generateFraudProof,proto3,oneof" json:"generate_fraud_proof,omitempty"`
+}
+type Request_TriggerFraudProofGenerationMode struct {
+	TriggerFraudProofGenerationMode *RequestTriggerFraudProofGenerationMode `protobuf:"bytes,18,opt,name=trigger_fraud_proof_generation_mode,json=triggerFraudProofGenerationMode,proto3,oneof" json:"trigger_fraud_proof_generation_mode,omitempty"`
+}
 
-func (*Request_Echo) isRequest_Value()               {}
-func (*Request_Flush) isRequest_Value()              {}
-func (*Request_Info) isRequest_Value()               {}
-func (*Request_SetOption) isRequest_Value()          {}
-func (*Request_InitChain) isRequest_Value()          {}
-func (*Request_Query) isRequest_Value()              {}
-func (*Request_BeginBlock) isRequest_Value()         {}
-func (*Request_CheckTx) isRequest_Value()            {}
-func (*Request_DeliverTx) isRequest_Value()          {}
-func (*Request_EndBlock) isRequest_Value()           {}
-func (*Request_Commit) isRequest_Value()             {}
-func (*Request_ListSnapshots) isRequest_Value()      {}
-func (*Request_OfferSnapshot) isRequest_Value()      {}
-func (*Request_LoadSnapshotChunk) isRequest_Value()  {}
-func (*Request_ApplySnapshotChunk) isRequest_Value() {}
+func (*Request_Echo) isRequest_Value()                            {}
+func (*Request_Flush) isRequest_Value()                           {}
+func (*Request_Info) isRequest_Value()                            {}
+func (*Request_SetOption) isRequest_Value()                       {}
+func (*Request_InitChain) isRequest_Value()                       {}
+func (*Request_Query) isRequest_Value()                           {}
+func (*Request_BeginBlock) isRequest_Value()                      {}
+func (*Request_CheckTx) isRequest_Value()                         {}
+func (*Request_DeliverTx) isRequest_Value()                       {}
+func (*Request_EndBlock) isRequest_Value()                        {}
+func (*Request_Commit) isRequest_Value()                          {}
+func (*Request_ListSnapshots) isRequest_Value()                   {}
+func (*Request_OfferSnapshot) isRequest_Value()                   {}
+func (*Request_LoadSnapshotChunk) isRequest_Value()               {}
+func (*Request_ApplySnapshotChunk) isRequest_Value()              {}
+func (*Request_GetAppHash) isRequest_Value()                      {}
+func (*Request_GenerateFraudProof) isRequest_Value()              {}
+func (*Request_TriggerFraudProofGenerationMode) isRequest_Value() {}
 
 func (m *Request) GetValue() isRequest_Value {
 	if m != nil {
@@ -393,6 +408,27 @@ func (m *Request) GetApplySnapshotChunk() *RequestApplySnapshotChunk {
 	return nil
 }
 
+func (m *Request) GetGetAppHash() *RequestGetAppHash {
+	if x, ok := m.GetValue().(*Request_GetAppHash); ok {
+		return x.GetAppHash
+	}
+	return nil
+}
+
+func (m *Request) GetGenerateFraudProof() *RequestGenerateFraudProof {
+	if x, ok := m.GetValue().(*Request_GenerateFraudProof); ok {
+		return x.GenerateFraudProof
+	}
+	return nil
+}
+
+func (m *Request) GetTriggerFraudProofGenerationMode() *RequestTriggerFraudProofGenerationMode {
+	if x, ok := m.GetValue().(*Request_TriggerFraudProofGenerationMode); ok {
+		return x.TriggerFraudProofGenerationMode
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*Request) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
@@ -411,6 +447,9 @@ func (*Request) XXX_OneofWrappers() []interface{} {
 		(*Request_OfferSnapshot)(nil),
 		(*Request_LoadSnapshotChunk)(nil),
 		(*Request_ApplySnapshotChunk)(nil),
+		(*Request_GetAppHash)(nil),
+		(*Request_GenerateFraudProof)(nil),
+		(*Request_TriggerFraudProofGenerationMode)(nil),
 	}
 }
 
@@ -1215,6 +1254,119 @@ func (m *RequestApplySnapshotChunk) GetSender() string {
 	return ""
 }
 
+// Gets the current appHash
+type RequestGetAppHash struct {
+}
+
+func (m *RequestGetAppHash) Reset()         { *m = RequestGetAppHash{} }
+func (m *RequestGetAppHash) String() string { return proto.CompactTextString(m) }
+func (*RequestGetAppHash) ProtoMessage()    {}
+func (*RequestGetAppHash) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{16}
+}
+func (m *RequestGetAppHash) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RequestGetAppHash) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RequestGetAppHash.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RequestGetAppHash) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RequestGetAppHash.Merge(m, src)
+}
+func (m *RequestGetAppHash) XXX_Size() int {
+	return m.Size()
+}
+func (m *RequestGetAppHash) XXX_DiscardUnknown() {
+	xxx_messageInfo_RequestGetAppHash.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RequestGetAppHash proto.InternalMessageInfo
+
+// Generates a fraud proof
+type RequestGenerateFraudProof struct {
+}
+
+func (m *RequestGenerateFraudProof) Reset()         { *m = RequestGenerateFraudProof{} }
+func (m *RequestGenerateFraudProof) String() string { return proto.CompactTextString(m) }
+func (*RequestGenerateFraudProof) ProtoMessage()    {}
+func (*RequestGenerateFraudProof) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{17}
+}
+func (m *RequestGenerateFraudProof) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RequestGenerateFraudProof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RequestGenerateFraudProof.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RequestGenerateFraudProof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RequestGenerateFraudProof.Merge(m, src)
+}
+func (m *RequestGenerateFraudProof) XXX_Size() int {
+	return m.Size()
+}
+func (m *RequestGenerateFraudProof) XXX_DiscardUnknown() {
+	xxx_messageInfo_RequestGenerateFraudProof.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RequestGenerateFraudProof proto.InternalMessageInfo
+
+// Triggers fraud proof generation mode
+type RequestTriggerFraudProofGenerationMode struct {
+}
+
+func (m *RequestTriggerFraudProofGenerationMode) Reset() {
+	*m = RequestTriggerFraudProofGenerationMode{}
+}
+func (m *RequestTriggerFraudProofGenerationMode) String() string { return proto.CompactTextString(m) }
+func (*RequestTriggerFraudProofGenerationMode) ProtoMessage()    {}
+func (*RequestTriggerFraudProofGenerationMode) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{18}
+}
+func (m *RequestTriggerFraudProofGenerationMode) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RequestTriggerFraudProofGenerationMode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RequestTriggerFraudProofGenerationMode.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RequestTriggerFraudProofGenerationMode) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RequestTriggerFraudProofGenerationMode.Merge(m, src)
+}
+func (m *RequestTriggerFraudProofGenerationMode) XXX_Size() int {
+	return m.Size()
+}
+func (m *RequestTriggerFraudProofGenerationMode) XXX_DiscardUnknown() {
+	xxx_messageInfo_RequestTriggerFraudProofGenerationMode.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RequestTriggerFraudProofGenerationMode proto.InternalMessageInfo
+
 type Response struct {
 	// Types that are valid to be assigned to Value:
 	//	*Response_Exception
@@ -1233,6 +1385,9 @@ type Response struct {
 	//	*Response_OfferSnapshot
 	//	*Response_LoadSnapshotChunk
 	//	*Response_ApplySnapshotChunk
+	//	*Response_GetAppHash
+	//	*Response_GenerateFraudProof
+	//	*Response_TriggerFraudProofGenerationMode
 	Value isResponse_Value `protobuf_oneof:"value"`
 }
 
@@ -1240,7 +1395,7 @@ func (m *Response) Reset()         { *m = Response{} }
 func (m *Response) String() string { return proto.CompactTextString(m) }
 func (*Response) ProtoMessage()    {}
 func (*Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{16}
+	return fileDescriptor_252557cfdd89a31a, []int{19}
 }
 func (m *Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1323,23 +1478,35 @@ type Response_LoadSnapshotChunk struct {
 type Response_ApplySnapshotChunk struct {
 	ApplySnapshotChunk *ResponseApplySnapshotChunk `protobuf:"bytes,16,opt,name=apply_snapshot_chunk,json=applySnapshotChunk,proto3,oneof" json:"apply_snapshot_chunk,omitempty"`
 }
+type Response_GetAppHash struct {
+	GetAppHash *ResponseGetAppHash `protobuf:"bytes,17,opt,name=get_app_hash,json=getAppHash,proto3,oneof" json:"get_app_hash,omitempty"`
+}
+type Response_GenerateFraudProof struct {
+	GenerateFraudProof *ResponseGenerateFraudProof `protobuf:"bytes,18,opt,name=generate_fraud_proof,json=generateFraudProof,proto3,oneof" json:"generate_fraud_proof,omitempty"`
+}
+type Response_TriggerFraudProofGenerationMode struct {
+	TriggerFraudProofGenerationMode *ResponseTriggerFraudProofGenerationMode `protobuf:"bytes,19,opt,name=trigger_fraud_proof_generation_mode,json=triggerFraudProofGenerationMode,proto3,oneof" json:"trigger_fraud_proof_generation_mode,omitempty"`
+}
 
-func (*Response_Exception) isResponse_Value()          {}
-func (*Response_Echo) isResponse_Value()               {}
-func (*Response_Flush) isResponse_Value()              {}
-func (*Response_Info) isResponse_Value()               {}
-func (*Response_SetOption) isResponse_Value()          {}
-func (*Response_InitChain) isResponse_Value()          {}
-func (*Response_Query) isResponse_Value()              {}
-func (*Response_BeginBlock) isResponse_Value()         {}
-func (*Response_CheckTx) isResponse_Value()            {}
-func (*Response_DeliverTx) isResponse_Value()          {}
-func (*Response_EndBlock) isResponse_Value()           {}
-func (*Response_Commit) isResponse_Value()             {}
-func (*Response_ListSnapshots) isResponse_Value()      {}
-func (*Response_OfferSnapshot) isResponse_Value()      {}
-func (*Response_LoadSnapshotChunk) isResponse_Value()  {}
-func (*Response_ApplySnapshotChunk) isResponse_Value() {}
+func (*Response_Exception) isResponse_Value()                       {}
+func (*Response_Echo) isResponse_Value()                            {}
+func (*Response_Flush) isResponse_Value()                           {}
+func (*Response_Info) isResponse_Value()                            {}
+func (*Response_SetOption) isResponse_Value()                       {}
+func (*Response_InitChain) isResponse_Value()                       {}
+func (*Response_Query) isResponse_Value()                           {}
+func (*Response_BeginBlock) isResponse_Value()                      {}
+func (*Response_CheckTx) isResponse_Value()                         {}
+func (*Response_DeliverTx) isResponse_Value()                       {}
+func (*Response_EndBlock) isResponse_Value()                        {}
+func (*Response_Commit) isResponse_Value()                          {}
+func (*Response_ListSnapshots) isResponse_Value()                   {}
+func (*Response_OfferSnapshot) isResponse_Value()                   {}
+func (*Response_LoadSnapshotChunk) isResponse_Value()               {}
+func (*Response_ApplySnapshotChunk) isResponse_Value()              {}
+func (*Response_GetAppHash) isResponse_Value()                      {}
+func (*Response_GenerateFraudProof) isResponse_Value()              {}
+func (*Response_TriggerFraudProofGenerationMode) isResponse_Value() {}
 
 func (m *Response) GetValue() isResponse_Value {
 	if m != nil {
@@ -1460,6 +1627,27 @@ func (m *Response) GetApplySnapshotChunk() *ResponseApplySnapshotChunk {
 	return nil
 }
 
+func (m *Response) GetGetAppHash() *ResponseGetAppHash {
+	if x, ok := m.GetValue().(*Response_GetAppHash); ok {
+		return x.GetAppHash
+	}
+	return nil
+}
+
+func (m *Response) GetGenerateFraudProof() *ResponseGenerateFraudProof {
+	if x, ok := m.GetValue().(*Response_GenerateFraudProof); ok {
+		return x.GenerateFraudProof
+	}
+	return nil
+}
+
+func (m *Response) GetTriggerFraudProofGenerationMode() *ResponseTriggerFraudProofGenerationMode {
+	if x, ok := m.GetValue().(*Response_TriggerFraudProofGenerationMode); ok {
+		return x.TriggerFraudProofGenerationMode
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*Response) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
@@ -1479,6 +1667,9 @@ func (*Response) XXX_OneofWrappers() []interface{} {
 		(*Response_OfferSnapshot)(nil),
 		(*Response_LoadSnapshotChunk)(nil),
 		(*Response_ApplySnapshotChunk)(nil),
+		(*Response_GetAppHash)(nil),
+		(*Response_GenerateFraudProof)(nil),
+		(*Response_TriggerFraudProofGenerationMode)(nil),
 	}
 }
 
@@ -1491,7 +1682,7 @@ func (m *ResponseException) Reset()         { *m = ResponseException{} }
 func (m *ResponseException) String() string { return proto.CompactTextString(m) }
 func (*ResponseException) ProtoMessage()    {}
 func (*ResponseException) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{17}
+	return fileDescriptor_252557cfdd89a31a, []int{20}
 }
 func (m *ResponseException) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1535,7 +1726,7 @@ func (m *ResponseEcho) Reset()         { *m = ResponseEcho{} }
 func (m *ResponseEcho) String() string { return proto.CompactTextString(m) }
 func (*ResponseEcho) ProtoMessage()    {}
 func (*ResponseEcho) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{18}
+	return fileDescriptor_252557cfdd89a31a, []int{21}
 }
 func (m *ResponseEcho) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1578,7 +1769,7 @@ func (m *ResponseFlush) Reset()         { *m = ResponseFlush{} }
 func (m *ResponseFlush) String() string { return proto.CompactTextString(m) }
 func (*ResponseFlush) ProtoMessage()    {}
 func (*ResponseFlush) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{19}
+	return fileDescriptor_252557cfdd89a31a, []int{22}
 }
 func (m *ResponseFlush) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1619,7 +1810,7 @@ func (m *ResponseInfo) Reset()         { *m = ResponseInfo{} }
 func (m *ResponseInfo) String() string { return proto.CompactTextString(m) }
 func (*ResponseInfo) ProtoMessage()    {}
 func (*ResponseInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{20}
+	return fileDescriptor_252557cfdd89a31a, []int{23}
 }
 func (m *ResponseInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1695,7 +1886,7 @@ func (m *ResponseSetOption) Reset()         { *m = ResponseSetOption{} }
 func (m *ResponseSetOption) String() string { return proto.CompactTextString(m) }
 func (*ResponseSetOption) ProtoMessage()    {}
 func (*ResponseSetOption) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{21}
+	return fileDescriptor_252557cfdd89a31a, []int{24}
 }
 func (m *ResponseSetOption) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1755,7 +1946,7 @@ func (m *ResponseInitChain) Reset()         { *m = ResponseInitChain{} }
 func (m *ResponseInitChain) String() string { return proto.CompactTextString(m) }
 func (*ResponseInitChain) ProtoMessage()    {}
 func (*ResponseInitChain) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{22}
+	return fileDescriptor_252557cfdd89a31a, []int{25}
 }
 func (m *ResponseInitChain) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1822,7 +2013,7 @@ func (m *ResponseQuery) Reset()         { *m = ResponseQuery{} }
 func (m *ResponseQuery) String() string { return proto.CompactTextString(m) }
 func (*ResponseQuery) ProtoMessage()    {}
 func (*ResponseQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{23}
+	return fileDescriptor_252557cfdd89a31a, []int{26}
 }
 func (m *ResponseQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1922,7 +2113,7 @@ func (m *ResponseBeginBlock) Reset()         { *m = ResponseBeginBlock{} }
 func (m *ResponseBeginBlock) String() string { return proto.CompactTextString(m) }
 func (*ResponseBeginBlock) ProtoMessage()    {}
 func (*ResponseBeginBlock) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{24}
+	return fileDescriptor_252557cfdd89a31a, []int{27}
 }
 func (m *ResponseBeginBlock) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1973,7 +2164,7 @@ func (m *ResponseCheckTx) Reset()         { *m = ResponseCheckTx{} }
 func (m *ResponseCheckTx) String() string { return proto.CompactTextString(m) }
 func (*ResponseCheckTx) ProtoMessage()    {}
 func (*ResponseCheckTx) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{25}
+	return fileDescriptor_252557cfdd89a31a, []int{28}
 }
 func (m *ResponseCheckTx) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2073,7 +2264,7 @@ func (m *ResponseDeliverTx) Reset()         { *m = ResponseDeliverTx{} }
 func (m *ResponseDeliverTx) String() string { return proto.CompactTextString(m) }
 func (*ResponseDeliverTx) ProtoMessage()    {}
 func (*ResponseDeliverTx) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{26}
+	return fileDescriptor_252557cfdd89a31a, []int{29}
 }
 func (m *ResponseDeliverTx) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2168,7 +2359,7 @@ func (m *ResponseEndBlock) Reset()         { *m = ResponseEndBlock{} }
 func (m *ResponseEndBlock) String() string { return proto.CompactTextString(m) }
 func (*ResponseEndBlock) ProtoMessage()    {}
 func (*ResponseEndBlock) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{27}
+	return fileDescriptor_252557cfdd89a31a, []int{30}
 }
 func (m *ResponseEndBlock) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2228,7 +2419,7 @@ func (m *ResponseCommit) Reset()         { *m = ResponseCommit{} }
 func (m *ResponseCommit) String() string { return proto.CompactTextString(m) }
 func (*ResponseCommit) ProtoMessage()    {}
 func (*ResponseCommit) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{28}
+	return fileDescriptor_252557cfdd89a31a, []int{31}
 }
 func (m *ResponseCommit) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2279,7 +2470,7 @@ func (m *ResponseListSnapshots) Reset()         { *m = ResponseListSnapshots{} }
 func (m *ResponseListSnapshots) String() string { return proto.CompactTextString(m) }
 func (*ResponseListSnapshots) ProtoMessage()    {}
 func (*ResponseListSnapshots) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{29}
+	return fileDescriptor_252557cfdd89a31a, []int{32}
 }
 func (m *ResponseListSnapshots) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2323,7 +2514,7 @@ func (m *ResponseOfferSnapshot) Reset()         { *m = ResponseOfferSnapshot{} }
 func (m *ResponseOfferSnapshot) String() string { return proto.CompactTextString(m) }
 func (*ResponseOfferSnapshot) ProtoMessage()    {}
 func (*ResponseOfferSnapshot) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{30}
+	return fileDescriptor_252557cfdd89a31a, []int{33}
 }
 func (m *ResponseOfferSnapshot) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2367,7 +2558,7 @@ func (m *ResponseLoadSnapshotChunk) Reset()         { *m = ResponseLoadSnapshotC
 func (m *ResponseLoadSnapshotChunk) String() string { return proto.CompactTextString(m) }
 func (*ResponseLoadSnapshotChunk) ProtoMessage()    {}
 func (*ResponseLoadSnapshotChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{31}
+	return fileDescriptor_252557cfdd89a31a, []int{34}
 }
 func (m *ResponseLoadSnapshotChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2413,7 +2604,7 @@ func (m *ResponseApplySnapshotChunk) Reset()         { *m = ResponseApplySnapsho
 func (m *ResponseApplySnapshotChunk) String() string { return proto.CompactTextString(m) }
 func (*ResponseApplySnapshotChunk) ProtoMessage()    {}
 func (*ResponseApplySnapshotChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{32}
+	return fileDescriptor_252557cfdd89a31a, []int{35}
 }
 func (m *ResponseApplySnapshotChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2463,6 +2654,140 @@ func (m *ResponseApplySnapshotChunk) GetRejectSenders() []string {
 	return nil
 }
 
+type ResponseGetAppHash struct {
+	AppHash []byte `protobuf:"bytes,1,opt,name=app_hash,json=appHash,proto3" json:"app_hash,omitempty"`
+}
+
+func (m *ResponseGetAppHash) Reset()         { *m = ResponseGetAppHash{} }
+func (m *ResponseGetAppHash) String() string { return proto.CompactTextString(m) }
+func (*ResponseGetAppHash) ProtoMessage()    {}
+func (*ResponseGetAppHash) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{36}
+}
+func (m *ResponseGetAppHash) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ResponseGetAppHash) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ResponseGetAppHash.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ResponseGetAppHash) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ResponseGetAppHash.Merge(m, src)
+}
+func (m *ResponseGetAppHash) XXX_Size() int {
+	return m.Size()
+}
+func (m *ResponseGetAppHash) XXX_DiscardUnknown() {
+	xxx_messageInfo_ResponseGetAppHash.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ResponseGetAppHash proto.InternalMessageInfo
+
+func (m *ResponseGetAppHash) GetAppHash() []byte {
+	if m != nil {
+		return m.AppHash
+	}
+	return nil
+}
+
+type ResponseGenerateFraudProof struct {
+	FraudProof *FraudProof `protobuf:"bytes,1,opt,name=fraudProof,proto3" json:"fraudProof,omitempty"`
+}
+
+func (m *ResponseGenerateFraudProof) Reset()         { *m = ResponseGenerateFraudProof{} }
+func (m *ResponseGenerateFraudProof) String() string { return proto.CompactTextString(m) }
+func (*ResponseGenerateFraudProof) ProtoMessage()    {}
+func (*ResponseGenerateFraudProof) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{37}
+}
+func (m *ResponseGenerateFraudProof) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ResponseGenerateFraudProof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ResponseGenerateFraudProof.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ResponseGenerateFraudProof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ResponseGenerateFraudProof.Merge(m, src)
+}
+func (m *ResponseGenerateFraudProof) XXX_Size() int {
+	return m.Size()
+}
+func (m *ResponseGenerateFraudProof) XXX_DiscardUnknown() {
+	xxx_messageInfo_ResponseGenerateFraudProof.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ResponseGenerateFraudProof proto.InternalMessageInfo
+
+func (m *ResponseGenerateFraudProof) GetFraudProof() *FraudProof {
+	if m != nil {
+		return m.FraudProof
+	}
+	return nil
+}
+
+type ResponseTriggerFraudProofGenerationMode struct {
+	Success bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+}
+
+func (m *ResponseTriggerFraudProofGenerationMode) Reset() {
+	*m = ResponseTriggerFraudProofGenerationMode{}
+}
+func (m *ResponseTriggerFraudProofGenerationMode) String() string { return proto.CompactTextString(m) }
+func (*ResponseTriggerFraudProofGenerationMode) ProtoMessage()    {}
+func (*ResponseTriggerFraudProofGenerationMode) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{38}
+}
+func (m *ResponseTriggerFraudProofGenerationMode) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ResponseTriggerFraudProofGenerationMode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ResponseTriggerFraudProofGenerationMode.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ResponseTriggerFraudProofGenerationMode) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ResponseTriggerFraudProofGenerationMode.Merge(m, src)
+}
+func (m *ResponseTriggerFraudProofGenerationMode) XXX_Size() int {
+	return m.Size()
+}
+func (m *ResponseTriggerFraudProofGenerationMode) XXX_DiscardUnknown() {
+	xxx_messageInfo_ResponseTriggerFraudProofGenerationMode.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ResponseTriggerFraudProofGenerationMode proto.InternalMessageInfo
+
+func (m *ResponseTriggerFraudProofGenerationMode) GetSuccess() bool {
+	if m != nil {
+		return m.Success
+	}
+	return false
+}
+
 // ConsensusParams contains all consensus-relevant parameters
 // that can be adjusted by the abci app
 type ConsensusParams struct {
@@ -2476,7 +2801,7 @@ func (m *ConsensusParams) Reset()         { *m = ConsensusParams{} }
 func (m *ConsensusParams) String() string { return proto.CompactTextString(m) }
 func (*ConsensusParams) ProtoMessage()    {}
 func (*ConsensusParams) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{33}
+	return fileDescriptor_252557cfdd89a31a, []int{39}
 }
 func (m *ConsensusParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2545,7 +2870,7 @@ func (m *BlockParams) Reset()         { *m = BlockParams{} }
 func (m *BlockParams) String() string { return proto.CompactTextString(m) }
 func (*BlockParams) ProtoMessage()    {}
 func (*BlockParams) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{34}
+	return fileDescriptor_252557cfdd89a31a, []int{40}
 }
 func (m *BlockParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2597,7 +2922,7 @@ func (m *LastCommitInfo) Reset()         { *m = LastCommitInfo{} }
 func (m *LastCommitInfo) String() string { return proto.CompactTextString(m) }
 func (*LastCommitInfo) ProtoMessage()    {}
 func (*LastCommitInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{35}
+	return fileDescriptor_252557cfdd89a31a, []int{41}
 }
 func (m *LastCommitInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2652,7 +2977,7 @@ func (m *Event) Reset()         { *m = Event{} }
 func (m *Event) String() string { return proto.CompactTextString(m) }
 func (*Event) ProtoMessage()    {}
 func (*Event) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{36}
+	return fileDescriptor_252557cfdd89a31a, []int{42}
 }
 func (m *Event) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2706,7 +3031,7 @@ func (m *EventAttribute) Reset()         { *m = EventAttribute{} }
 func (m *EventAttribute) String() string { return proto.CompactTextString(m) }
 func (*EventAttribute) ProtoMessage()    {}
 func (*EventAttribute) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{37}
+	return fileDescriptor_252557cfdd89a31a, []int{43}
 }
 func (m *EventAttribute) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2770,7 +3095,7 @@ func (m *TxResult) Reset()         { *m = TxResult{} }
 func (m *TxResult) String() string { return proto.CompactTextString(m) }
 func (*TxResult) ProtoMessage()    {}
 func (*TxResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{38}
+	return fileDescriptor_252557cfdd89a31a, []int{44}
 }
 func (m *TxResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2838,7 +3163,7 @@ func (m *Validator) Reset()         { *m = Validator{} }
 func (m *Validator) String() string { return proto.CompactTextString(m) }
 func (*Validator) ProtoMessage()    {}
 func (*Validator) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{39}
+	return fileDescriptor_252557cfdd89a31a, []int{45}
 }
 func (m *Validator) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2891,7 +3216,7 @@ func (m *ValidatorUpdate) Reset()         { *m = ValidatorUpdate{} }
 func (m *ValidatorUpdate) String() string { return proto.CompactTextString(m) }
 func (*ValidatorUpdate) ProtoMessage()    {}
 func (*ValidatorUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{40}
+	return fileDescriptor_252557cfdd89a31a, []int{46}
 }
 func (m *ValidatorUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2944,7 +3269,7 @@ func (m *VoteInfo) Reset()         { *m = VoteInfo{} }
 func (m *VoteInfo) String() string { return proto.CompactTextString(m) }
 func (*VoteInfo) ProtoMessage()    {}
 func (*VoteInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{41}
+	return fileDescriptor_252557cfdd89a31a, []int{47}
 }
 func (m *VoteInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3005,7 +3330,7 @@ func (m *Evidence) Reset()         { *m = Evidence{} }
 func (m *Evidence) String() string { return proto.CompactTextString(m) }
 func (*Evidence) ProtoMessage()    {}
 func (*Evidence) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{42}
+	return fileDescriptor_252557cfdd89a31a, []int{48}
 }
 func (m *Evidence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3081,7 +3406,7 @@ func (m *Snapshot) Reset()         { *m = Snapshot{} }
 func (m *Snapshot) String() string { return proto.CompactTextString(m) }
 func (*Snapshot) ProtoMessage()    {}
 func (*Snapshot) Descriptor() ([]byte, []int) {
-	return fileDescriptor_252557cfdd89a31a, []int{43}
+	return fileDescriptor_252557cfdd89a31a, []int{49}
 }
 func (m *Snapshot) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3145,6 +3470,192 @@ func (m *Snapshot) GetMetadata() []byte {
 	return nil
 }
 
+// Represents a single-round fraudProof
+type FraudProof struct {
+	BlockHeight  int64                    `protobuf:"varint,1,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
+	AppHash      []byte                   `protobuf:"bytes,2,opt,name=appHash,proto3" json:"appHash,omitempty"`
+	StateWitness map[string]*StateWitness `protobuf:"bytes,3,rep,name=stateWitness,proto3" json:"stateWitness,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (m *FraudProof) Reset()         { *m = FraudProof{} }
+func (m *FraudProof) String() string { return proto.CompactTextString(m) }
+func (*FraudProof) ProtoMessage()    {}
+func (*FraudProof) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{50}
+}
+func (m *FraudProof) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *FraudProof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_FraudProof.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *FraudProof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FraudProof.Merge(m, src)
+}
+func (m *FraudProof) XXX_Size() int {
+	return m.Size()
+}
+func (m *FraudProof) XXX_DiscardUnknown() {
+	xxx_messageInfo_FraudProof.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FraudProof proto.InternalMessageInfo
+
+func (m *FraudProof) GetBlockHeight() int64 {
+	if m != nil {
+		return m.BlockHeight
+	}
+	return 0
+}
+
+func (m *FraudProof) GetAppHash() []byte {
+	if m != nil {
+		return m.AppHash
+	}
+	return nil
+}
+
+func (m *FraudProof) GetStateWitness() map[string]*StateWitness {
+	if m != nil {
+		return m.StateWitness
+	}
+	return nil
+}
+
+// State witness with a list of all witness data
+type StateWitness struct {
+	// store level proof
+	ProofOp *crypto.ProofOp `protobuf:"bytes,1,opt,name=proof_op,json=proofOp,proto3" json:"proof_op,omitempty"`
+	// substore level hash
+	RootHash []byte `protobuf:"bytes,2,opt,name=rootHash,proto3" json:"rootHash,omitempty"`
+	// List of witness data
+	WitnessData []*WitnessData `protobuf:"bytes,3,rep,name=witnessData,proto3" json:"witnessData,omitempty"`
+}
+
+func (m *StateWitness) Reset()         { *m = StateWitness{} }
+func (m *StateWitness) String() string { return proto.CompactTextString(m) }
+func (*StateWitness) ProtoMessage()    {}
+func (*StateWitness) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{51}
+}
+func (m *StateWitness) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StateWitness) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StateWitness.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StateWitness) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StateWitness.Merge(m, src)
+}
+func (m *StateWitness) XXX_Size() int {
+	return m.Size()
+}
+func (m *StateWitness) XXX_DiscardUnknown() {
+	xxx_messageInfo_StateWitness.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StateWitness proto.InternalMessageInfo
+
+func (m *StateWitness) GetProofOp() *crypto.ProofOp {
+	if m != nil {
+		return m.ProofOp
+	}
+	return nil
+}
+
+func (m *StateWitness) GetRootHash() []byte {
+	if m != nil {
+		return m.RootHash
+	}
+	return nil
+}
+
+func (m *StateWitness) GetWitnessData() []*WitnessData {
+	if m != nil {
+		return m.WitnessData
+	}
+	return nil
+}
+
+// Witness data containing a key/value pair and a SMT proof for said key/value pair
+type WitnessData struct {
+	Key   []byte          `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value []byte          `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Proof *crypto.ProofOp `protobuf:"bytes,3,opt,name=proof,proto3" json:"proof,omitempty"`
+}
+
+func (m *WitnessData) Reset()         { *m = WitnessData{} }
+func (m *WitnessData) String() string { return proto.CompactTextString(m) }
+func (*WitnessData) ProtoMessage()    {}
+func (*WitnessData) Descriptor() ([]byte, []int) {
+	return fileDescriptor_252557cfdd89a31a, []int{52}
+}
+func (m *WitnessData) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *WitnessData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_WitnessData.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *WitnessData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_WitnessData.Merge(m, src)
+}
+func (m *WitnessData) XXX_Size() int {
+	return m.Size()
+}
+func (m *WitnessData) XXX_DiscardUnknown() {
+	xxx_messageInfo_WitnessData.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_WitnessData proto.InternalMessageInfo
+
+func (m *WitnessData) GetKey() []byte {
+	if m != nil {
+		return m.Key
+	}
+	return nil
+}
+
+func (m *WitnessData) GetValue() []byte {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (m *WitnessData) GetProof() *crypto.ProofOp {
+	if m != nil {
+		return m.Proof
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterEnum("tendermint.abci.CheckTxType", CheckTxType_name, CheckTxType_value)
 	proto.RegisterEnum("tendermint.abci.EvidenceType", EvidenceType_name, EvidenceType_value)
@@ -3166,6 +3677,9 @@ func init() {
 	proto.RegisterType((*RequestOfferSnapshot)(nil), "tendermint.abci.RequestOfferSnapshot")
 	proto.RegisterType((*RequestLoadSnapshotChunk)(nil), "tendermint.abci.RequestLoadSnapshotChunk")
 	proto.RegisterType((*RequestApplySnapshotChunk)(nil), "tendermint.abci.RequestApplySnapshotChunk")
+	proto.RegisterType((*RequestGetAppHash)(nil), "tendermint.abci.RequestGetAppHash")
+	proto.RegisterType((*RequestGenerateFraudProof)(nil), "tendermint.abci.RequestGenerateFraudProof")
+	proto.RegisterType((*RequestTriggerFraudProofGenerationMode)(nil), "tendermint.abci.RequestTriggerFraudProofGenerationMode")
 	proto.RegisterType((*Response)(nil), "tendermint.abci.Response")
 	proto.RegisterType((*ResponseException)(nil), "tendermint.abci.ResponseException")
 	proto.RegisterType((*ResponseEcho)(nil), "tendermint.abci.ResponseEcho")
@@ -3183,6 +3697,9 @@ func init() {
 	proto.RegisterType((*ResponseOfferSnapshot)(nil), "tendermint.abci.ResponseOfferSnapshot")
 	proto.RegisterType((*ResponseLoadSnapshotChunk)(nil), "tendermint.abci.ResponseLoadSnapshotChunk")
 	proto.RegisterType((*ResponseApplySnapshotChunk)(nil), "tendermint.abci.ResponseApplySnapshotChunk")
+	proto.RegisterType((*ResponseGetAppHash)(nil), "tendermint.abci.ResponseGetAppHash")
+	proto.RegisterType((*ResponseGenerateFraudProof)(nil), "tendermint.abci.ResponseGenerateFraudProof")
+	proto.RegisterType((*ResponseTriggerFraudProofGenerationMode)(nil), "tendermint.abci.ResponseTriggerFraudProofGenerationMode")
 	proto.RegisterType((*ConsensusParams)(nil), "tendermint.abci.ConsensusParams")
 	proto.RegisterType((*BlockParams)(nil), "tendermint.abci.BlockParams")
 	proto.RegisterType((*LastCommitInfo)(nil), "tendermint.abci.LastCommitInfo")
@@ -3194,184 +3711,213 @@ func init() {
 	proto.RegisterType((*VoteInfo)(nil), "tendermint.abci.VoteInfo")
 	proto.RegisterType((*Evidence)(nil), "tendermint.abci.Evidence")
 	proto.RegisterType((*Snapshot)(nil), "tendermint.abci.Snapshot")
+	proto.RegisterType((*FraudProof)(nil), "tendermint.abci.FraudProof")
+	proto.RegisterMapType((map[string]*StateWitness)(nil), "tendermint.abci.FraudProof.StateWitnessEntry")
+	proto.RegisterType((*StateWitness)(nil), "tendermint.abci.StateWitness")
+	proto.RegisterType((*WitnessData)(nil), "tendermint.abci.WitnessData")
 }
 
 func init() { proto.RegisterFile("tendermint/abci/types.proto", fileDescriptor_252557cfdd89a31a) }
 
 var fileDescriptor_252557cfdd89a31a = []byte{
-	// 2741 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x5a, 0x4b, 0x73, 0x1b, 0xc7,
-	0x11, 0xc6, 0xfb, 0xd1, 0x24, 0x1e, 0x1c, 0xd1, 0x12, 0xb4, 0x92, 0x48, 0x79, 0x55, 0x72, 0x2c,
-	0xd9, 0x26, 0x63, 0xaa, 0xa4, 0x48, 0xb1, 0x13, 0x9b, 0x80, 0x20, 0x83, 0x26, 0x4d, 0x30, 0x4b,
-	0x48, 0xce, 0xcb, 0x5a, 0x2f, 0xb0, 0x43, 0x60, 0x2d, 0x60, 0x77, 0x8d, 0x1d, 0x50, 0xa4, 0x8f,
-	0x71, 0x72, 0x51, 0x2e, 0xce, 0x2d, 0x17, 0xff, 0x8f, 0x9c, 0x72, 0xc9, 0xc5, 0x55, 0xb9, 0xf8,
-	0x98, 0x93, 0x93, 0x92, 0x2a, 0x97, 0xfc, 0x81, 0x9c, 0x52, 0x49, 0xcd, 0x63, 0x5f, 0x00, 0x16,
-	0x00, 0xed, 0xdc, 0x7c, 0x9b, 0x99, 0xed, 0xee, 0xc5, 0xf4, 0x4e, 0x7f, 0xfd, 0x75, 0x0f, 0xe0,
-	0x12, 0xc1, 0xa6, 0x8e, 0x87, 0x03, 0xc3, 0x24, 0x9b, 0x5a, 0xbb, 0x63, 0x6c, 0x92, 0x53, 0x1b,
-	0x3b, 0x1b, 0xf6, 0xd0, 0x22, 0x16, 0x2a, 0xf9, 0x0f, 0x37, 0xe8, 0x43, 0xe9, 0x4a, 0x40, 0xba,
-	0x33, 0x3c, 0xb5, 0x89, 0xb5, 0x69, 0x0f, 0x2d, 0xeb, 0x88, 0xcb, 0x4b, 0x97, 0x03, 0x8f, 0x99,
-	0x9d, 0xa0, 0xb5, 0xd0, 0x53, 0xa1, 0xfc, 0x04, 0x9f, 0xba, 0x4f, 0xaf, 0x4c, 0xe8, 0xda, 0xda,
-	0x50, 0x1b, 0xb8, 0x8f, 0xd7, 0xbb, 0x96, 0xd5, 0xed, 0xe3, 0x4d, 0x36, 0x6b, 0x8f, 0x8e, 0x36,
-	0x89, 0x31, 0xc0, 0x0e, 0xd1, 0x06, 0xb6, 0x10, 0x58, 0xed, 0x5a, 0x5d, 0x8b, 0x0d, 0x37, 0xe9,
-	0x88, 0xaf, 0xca, 0x7f, 0xc8, 0x41, 0x56, 0xc1, 0x9f, 0x8e, 0xb0, 0x43, 0xd0, 0x16, 0xa4, 0x70,
-	0xa7, 0x67, 0x55, 0xe2, 0x57, 0xe3, 0xaf, 0x2e, 0x6d, 0x5d, 0xde, 0x18, 0xdb, 0xdc, 0x86, 0x90,
-	0xab, 0x77, 0x7a, 0x56, 0x23, 0xa6, 0x30, 0x59, 0x74, 0x1b, 0xd2, 0x47, 0xfd, 0x91, 0xd3, 0xab,
-	0x24, 0x98, 0xd2, 0x95, 0x28, 0xa5, 0x07, 0x54, 0xa8, 0x11, 0x53, 0xb8, 0x34, 0x7d, 0x95, 0x61,
-	0x1e, 0x59, 0x95, 0xe4, 0xec, 0x57, 0xed, 0x98, 0x47, 0xec, 0x55, 0x54, 0x16, 0x55, 0x01, 0x1c,
-	0x4c, 0x54, 0xcb, 0x26, 0x86, 0x65, 0x56, 0x52, 0x4c, 0xf3, 0xe5, 0x28, 0xcd, 0x43, 0x4c, 0x9a,
-	0x4c, 0xb0, 0x11, 0x53, 0xf2, 0x8e, 0x3b, 0xa1, 0x36, 0x0c, 0xd3, 0x20, 0x6a, 0xa7, 0xa7, 0x19,
-	0x66, 0x25, 0x3d, 0xdb, 0xc6, 0x8e, 0x69, 0x90, 0x1a, 0x15, 0xa4, 0x36, 0x0c, 0x77, 0x42, 0xb7,
-	0xfc, 0xe9, 0x08, 0x0f, 0x4f, 0x2b, 0x99, 0xd9, 0x5b, 0xfe, 0x19, 0x15, 0xa2, 0x5b, 0x66, 0xd2,
-	0xa8, 0x0e, 0x4b, 0x6d, 0xdc, 0x35, 0x4c, 0xb5, 0xdd, 0xb7, 0x3a, 0x4f, 0x2a, 0x59, 0xa6, 0x2c,
-	0x47, 0x29, 0x57, 0xa9, 0x68, 0x95, 0x4a, 0x36, 0x62, 0x0a, 0xb4, 0xbd, 0x19, 0x7a, 0x1b, 0x72,
-	0x9d, 0x1e, 0xee, 0x3c, 0x51, 0xc9, 0x49, 0x25, 0xc7, 0x6c, 0xac, 0x47, 0xd9, 0xa8, 0x51, 0xb9,
-	0xd6, 0x49, 0x23, 0xa6, 0x64, 0x3b, 0x7c, 0x48, 0xf7, 0xaf, 0xe3, 0xbe, 0x71, 0x8c, 0x87, 0x54,
-	0x3f, 0x3f, 0x7b, 0xff, 0xf7, 0xb9, 0x24, 0xb3, 0x90, 0xd7, 0xdd, 0x09, 0x7a, 0x07, 0xf2, 0xd8,
-	0xd4, 0xc5, 0x36, 0x80, 0x99, 0xb8, 0x1a, 0x79, 0x56, 0x4c, 0xdd, 0xdd, 0x44, 0x0e, 0x8b, 0x31,
-	0xba, 0x0b, 0x99, 0x8e, 0x35, 0x18, 0x18, 0xa4, 0xb2, 0xc4, 0xb4, 0xd7, 0x22, 0x37, 0xc0, 0xa4,
-	0x1a, 0x31, 0x45, 0xc8, 0xa3, 0x7d, 0x28, 0xf6, 0x0d, 0x87, 0xa8, 0x8e, 0xa9, 0xd9, 0x4e, 0xcf,
-	0x22, 0x4e, 0x65, 0x99, 0x59, 0xb8, 0x1e, 0x65, 0x61, 0xcf, 0x70, 0xc8, 0xa1, 0x2b, 0xdc, 0x88,
-	0x29, 0x85, 0x7e, 0x70, 0x81, 0xda, 0xb3, 0x8e, 0x8e, 0xf0, 0xd0, 0x33, 0x58, 0x29, 0xcc, 0xb6,
-	0xd7, 0xa4, 0xd2, 0xae, 0x3e, 0xb5, 0x67, 0x05, 0x17, 0xd0, 0xaf, 0xe0, 0x5c, 0xdf, 0xd2, 0x74,
-	0xcf, 0x9c, 0xda, 0xe9, 0x8d, 0xcc, 0x27, 0x95, 0x22, 0x33, 0x7a, 0x23, 0xf2, 0x47, 0x5a, 0x9a,
-	0xee, 0x9a, 0xa8, 0x51, 0x85, 0x46, 0x4c, 0x59, 0xe9, 0x8f, 0x2f, 0xa2, 0xc7, 0xb0, 0xaa, 0xd9,
-	0x76, 0xff, 0x74, 0xdc, 0x7a, 0x89, 0x59, 0xbf, 0x19, 0x65, 0x7d, 0x9b, 0xea, 0x8c, 0x9b, 0x47,
-	0xda, 0xc4, 0x6a, 0x35, 0x0b, 0xe9, 0x63, 0xad, 0x3f, 0xc2, 0xf2, 0x0f, 0x60, 0x29, 0x10, 0xea,
-	0xa8, 0x02, 0xd9, 0x01, 0x76, 0x1c, 0xad, 0x8b, 0x19, 0x32, 0xe4, 0x15, 0x77, 0x2a, 0x17, 0x61,
-	0x39, 0x18, 0xde, 0xf2, 0xc0, 0x53, 0xa4, 0x81, 0x4b, 0x15, 0x8f, 0xf1, 0xd0, 0xa1, 0xd1, 0x2a,
-	0x14, 0xc5, 0x14, 0x5d, 0x83, 0x02, 0x3b, 0x3e, 0xaa, 0xfb, 0x9c, 0xa2, 0x47, 0x4a, 0x59, 0x66,
-	0x8b, 0x8f, 0x84, 0xd0, 0x3a, 0x2c, 0xd9, 0x5b, 0xb6, 0x27, 0x92, 0x64, 0x22, 0x60, 0x6f, 0xd9,
-	0x42, 0x40, 0xfe, 0x31, 0x94, 0xc7, 0xa3, 0x1d, 0x95, 0x21, 0xf9, 0x04, 0x9f, 0x8a, 0xf7, 0xd1,
-	0x21, 0x5a, 0x15, 0xdb, 0x62, 0xef, 0xc8, 0x2b, 0x62, 0x8f, 0x7f, 0x4d, 0x78, 0xca, 0x5e, 0x98,
-	0xa3, 0xbb, 0x90, 0xa2, 0xa8, 0x29, 0x00, 0x50, 0xda, 0xe0, 0x90, 0xba, 0xe1, 0x42, 0xea, 0x46,
-	0xcb, 0x85, 0xd4, 0x6a, 0xee, 0xab, 0x6f, 0xd6, 0x63, 0x5f, 0xfc, 0x7d, 0x3d, 0xae, 0x30, 0x0d,
-	0x74, 0x91, 0x46, 0xa5, 0x66, 0x98, 0xaa, 0xa1, 0x8b, 0xf7, 0x64, 0xd9, 0x7c, 0x47, 0x47, 0xbb,
-	0x50, 0xee, 0x58, 0xa6, 0x83, 0x4d, 0x67, 0xe4, 0xa8, 0x1c, 0xb2, 0x05, 0xec, 0x4d, 0x46, 0x4d,
-	0xcd, 0x15, 0x3c, 0x60, 0x72, 0x4a, 0xa9, 0x13, 0x5e, 0x40, 0x0f, 0x00, 0x8e, 0xb5, 0xbe, 0xa1,
-	0x6b, 0xc4, 0x1a, 0x3a, 0x95, 0xd4, 0xd5, 0xe4, 0x54, 0x33, 0x8f, 0x5c, 0x91, 0x87, 0xb6, 0xae,
-	0x11, 0x5c, 0x4d, 0xd1, 0x5f, 0xab, 0x04, 0x34, 0xd1, 0x2b, 0x50, 0xd2, 0x6c, 0x5b, 0x75, 0x88,
-	0x46, 0xb0, 0xda, 0x3e, 0x25, 0xd8, 0x61, 0x60, 0xb8, 0xac, 0x14, 0x34, 0xdb, 0x3e, 0xa4, 0xab,
-	0x55, 0xba, 0x88, 0xae, 0x43, 0x91, 0x02, 0x9f, 0xa1, 0xf5, 0xd5, 0x1e, 0x36, 0xba, 0x3d, 0xc2,
-	0x40, 0x2f, 0xa9, 0x14, 0xc4, 0x6a, 0x83, 0x2d, 0xca, 0xba, 0x77, 0x10, 0x18, 0xe8, 0x21, 0x04,
-	0x29, 0x5d, 0x23, 0x1a, 0x73, 0xe4, 0xb2, 0xc2, 0xc6, 0x74, 0xcd, 0xd6, 0x48, 0x4f, 0xb8, 0x87,
-	0x8d, 0xd1, 0x79, 0xc8, 0x08, 0xb3, 0x49, 0x66, 0x56, 0xcc, 0xe8, 0x37, 0xb3, 0x87, 0xd6, 0x31,
-	0x66, 0x28, 0x9f, 0x53, 0xf8, 0x44, 0xfe, 0x6d, 0x02, 0x56, 0x26, 0xe0, 0x91, 0xda, 0xed, 0x69,
-	0x4e, 0xcf, 0x7d, 0x17, 0x1d, 0xa3, 0x3b, 0xd4, 0xae, 0xa6, 0xe3, 0xa1, 0x48, 0x4b, 0x95, 0xa0,
-	0x8b, 0x78, 0xca, 0x6d, 0xb0, 0xe7, 0xc2, 0x35, 0x42, 0x1a, 0x35, 0xa1, 0xdc, 0xd7, 0x1c, 0xa2,
-	0x72, 0xb8, 0x51, 0x03, 0x29, 0x6a, 0x12, 0x64, 0xf7, 0x34, 0x17, 0xa0, 0xe8, 0x61, 0x17, 0x86,
-	0x8a, 0xfd, 0xd0, 0x2a, 0x52, 0x60, 0xb5, 0x7d, 0xfa, 0x99, 0x66, 0x12, 0xc3, 0xc4, 0xea, 0xc4,
-	0x97, 0xbb, 0x38, 0x61, 0xb4, 0x7e, 0x6c, 0xe8, 0xd8, 0xec, 0xb8, 0x9f, 0xec, 0x9c, 0xa7, 0xec,
-	0x7d, 0x52, 0x47, 0x56, 0xa0, 0x18, 0x06, 0x78, 0x54, 0x84, 0x04, 0x39, 0x11, 0x0e, 0x48, 0x90,
-	0x13, 0xf4, 0x43, 0x48, 0xd1, 0x4d, 0xb2, 0xcd, 0x17, 0xa7, 0x64, 0x57, 0xa1, 0xd7, 0x3a, 0xb5,
-	0xb1, 0xc2, 0x24, 0x65, 0xd9, 0x8b, 0x06, 0x0f, 0xf4, 0xc7, 0xad, 0xca, 0x37, 0xa0, 0x34, 0x86,
-	0xea, 0x81, 0xef, 0x17, 0x0f, 0x7e, 0x3f, 0xb9, 0x04, 0x85, 0x10, 0x84, 0xcb, 0xe7, 0x61, 0x75,
-	0x1a, 0x22, 0xcb, 0x3d, 0x6f, 0x3d, 0x84, 0xac, 0xe8, 0x36, 0xe4, 0x3c, 0x48, 0xe6, 0xd1, 0x38,
-	0xe9, 0x2b, 0x57, 0x58, 0xf1, 0x44, 0x69, 0x18, 0xd2, 0x63, 0xcd, 0xce, 0x43, 0x82, 0xfd, 0xf0,
-	0xac, 0x66, 0xdb, 0x0d, 0xcd, 0xe9, 0xc9, 0x1f, 0x43, 0x25, 0x0a, 0x6e, 0xc7, 0xb6, 0x91, 0xf2,
-	0x8e, 0xe1, 0x79, 0xc8, 0x1c, 0x59, 0xc3, 0x81, 0x46, 0x98, 0xb1, 0x82, 0x22, 0x66, 0xf4, 0x78,
-	0x72, 0xe8, 0x4d, 0xb2, 0x65, 0x3e, 0x91, 0x55, 0xb8, 0x18, 0x09, 0xb9, 0x54, 0xc5, 0x30, 0x75,
-	0xcc, 0xfd, 0x59, 0x50, 0xf8, 0xc4, 0x37, 0xc4, 0x7f, 0x2c, 0x9f, 0xd0, 0xd7, 0x3a, 0x6c, 0xaf,
-	0xcc, 0x7e, 0x5e, 0x11, 0x33, 0xf9, 0x9f, 0x39, 0xc8, 0x29, 0xd8, 0xb1, 0x29, 0x26, 0xa0, 0x2a,
-	0xe4, 0xf1, 0x49, 0x07, 0x73, 0x32, 0x14, 0x8f, 0x24, 0x13, 0x5c, 0xba, 0xee, 0x4a, 0xd2, 0x4c,
-	0xee, 0xa9, 0xa1, 0x5b, 0x82, 0xf0, 0x45, 0x73, 0x37, 0xa1, 0x1e, 0x64, 0x7c, 0x77, 0x5c, 0xc6,
-	0x97, 0x8c, 0x4c, 0xde, 0x5c, 0x6b, 0x8c, 0xf2, 0xdd, 0x12, 0x94, 0x2f, 0x35, 0xe7, 0x65, 0x21,
-	0xce, 0x57, 0x0b, 0x71, 0xbe, 0xf4, 0x9c, 0x6d, 0x46, 0x90, 0xbe, 0x5a, 0x88, 0xf4, 0x65, 0xe6,
-	0x18, 0x89, 0x60, 0x7d, 0x77, 0x5c, 0xd6, 0x97, 0x9d, 0xb3, 0xed, 0x31, 0xda, 0xf7, 0x20, 0x4c,
-	0xfb, 0x38, 0x65, 0xbb, 0x16, 0xa9, 0x1d, 0xc9, 0xfb, 0x7e, 0x12, 0xe0, 0x7d, 0xf9, 0x48, 0xd2,
-	0xc5, 0x8d, 0x4c, 0x21, 0x7e, 0xb5, 0x10, 0xf1, 0x83, 0x39, 0x3e, 0x88, 0x60, 0x7e, 0xef, 0x06,
-	0x99, 0xdf, 0x52, 0x24, 0x79, 0x14, 0x87, 0x66, 0x1a, 0xf5, 0xbb, 0xe7, 0x51, 0xbf, 0xe5, 0x48,
-	0xee, 0x2a, 0xf6, 0x30, 0xce, 0xfd, 0x9a, 0x13, 0xdc, 0x8f, 0x73, 0xb5, 0x57, 0x22, 0x4d, 0xcc,
-	0x21, 0x7f, 0xcd, 0x09, 0xf2, 0x57, 0x9c, 0x63, 0x70, 0x0e, 0xfb, 0xfb, 0xf5, 0x74, 0xf6, 0x17,
-	0xcd, 0xcf, 0xc4, 0xcf, 0x5c, 0x8c, 0xfe, 0xa9, 0x11, 0xf4, 0xaf, 0xcc, 0xcc, 0xbf, 0x16, 0x69,
-	0xfe, 0xec, 0xfc, 0xef, 0x06, 0x4d, 0xb3, 0x63, 0xc0, 0x41, 0xa1, 0x0a, 0x0f, 0x87, 0xd6, 0x50,
-	0x50, 0x2b, 0x3e, 0x91, 0x5f, 0xa5, 0x89, 0xdf, 0x07, 0x89, 0x19, 0x5c, 0x91, 0xa5, 0x84, 0x00,
-	0x30, 0xc8, 0x7f, 0x8a, 0xfb, 0xba, 0x2c, 0x57, 0x06, 0x49, 0x43, 0x5e, 0x90, 0x86, 0x00, 0x85,
-	0x4c, 0x84, 0x29, 0xe4, 0x3a, 0x2c, 0x51, 0xa8, 0x1f, 0x63, 0x87, 0x9a, 0xed, 0xb2, 0x43, 0x74,
-	0x13, 0x56, 0x58, 0x2e, 0xe7, 0x44, 0x53, 0xe0, 0x7b, 0x8a, 0xa5, 0xa9, 0x12, 0x7d, 0xc0, 0x0f,
-	0x27, 0x07, 0xfa, 0x37, 0xe0, 0x5c, 0x40, 0xd6, 0x4b, 0x21, 0x9c, 0x12, 0x95, 0x3d, 0xe9, 0x6d,
-	0x91, 0x4b, 0x3e, 0xf0, 0x1d, 0xe4, 0x33, 0x4f, 0x04, 0xa9, 0x8e, 0xa5, 0x63, 0x01, 0xf0, 0x6c,
-	0x4c, 0xd9, 0x68, 0xdf, 0xea, 0x0a, 0x18, 0xa7, 0x43, 0x2a, 0xe5, 0xa1, 0x60, 0x9e, 0x83, 0x9c,
-	0xfc, 0x97, 0xb8, 0x6f, 0xcf, 0x27, 0xa3, 0xd3, 0x78, 0x63, 0xfc, 0xff, 0xc3, 0x1b, 0x13, 0xdf,
-	0x9a, 0x37, 0x06, 0x13, 0x6c, 0x32, 0x9c, 0x60, 0xff, 0x1d, 0xf7, 0xbf, 0xb0, 0xc7, 0x02, 0xbf,
-	0x9d, 0x47, 0xfc, 0x6c, 0x99, 0x66, 0xdf, 0x4b, 0x64, 0x4b, 0xc1, 0xed, 0x33, 0xec, 0xbd, 0x61,
-	0x6e, 0x9f, 0xe5, 0xf9, 0x93, 0x4d, 0xd0, 0x5d, 0xc8, 0xb3, 0xa6, 0x8b, 0x6a, 0xd9, 0x8e, 0x00,
-	0xdc, 0x4b, 0xc1, 0xbd, 0xf2, 0xde, 0xca, 0xc6, 0x01, 0x95, 0x69, 0xda, 0x8e, 0x92, 0xb3, 0xc5,
-	0x28, 0x40, 0x04, 0xf2, 0x21, 0x3e, 0x7a, 0x19, 0xf2, 0xf4, 0xd7, 0x3b, 0xb6, 0xd6, 0xc1, 0x0c,
-	0x3c, 0xf3, 0x8a, 0xbf, 0x20, 0x3f, 0x06, 0x34, 0x09, 0xdf, 0xa8, 0x01, 0x19, 0x7c, 0x8c, 0x4d,
-	0x42, 0xbf, 0x1a, 0x75, 0xf7, 0xf9, 0x29, 0x64, 0x0f, 0x9b, 0xa4, 0x5a, 0xa1, 0x4e, 0xfe, 0xd7,
-	0x37, 0xeb, 0x65, 0x2e, 0xfd, 0xba, 0x35, 0x30, 0x08, 0x1e, 0xd8, 0xe4, 0x54, 0x11, 0xfa, 0xf2,
-	0xe7, 0x09, 0xca, 0xbc, 0x42, 0xd0, 0x3e, 0xd5, 0xb7, 0x6e, 0x00, 0x25, 0x02, 0xac, 0x7b, 0x31,
-	0x7f, 0xaf, 0x01, 0x74, 0x35, 0x47, 0x7d, 0xaa, 0x99, 0x04, 0xeb, 0xc2, 0xe9, 0x81, 0x15, 0x24,
-	0x41, 0x8e, 0xce, 0x46, 0x0e, 0xd6, 0x45, 0x01, 0xe0, 0xcd, 0x03, 0xfb, 0xcc, 0x7e, 0xb7, 0x7d,
-	0x86, 0xbd, 0x9c, 0x1b, 0xf7, 0xf2, 0xef, 0x12, 0x7e, 0x94, 0xf8, 0x24, 0xf5, 0xfb, 0xe7, 0x87,
-	0xdf, 0xb3, 0xca, 0x35, 0x9c, 0x63, 0xd1, 0x21, 0xac, 0x78, 0x51, 0xaa, 0x8e, 0x58, 0xf4, 0xba,
-	0xe7, 0x6e, 0xd1, 0x30, 0x2f, 0x1f, 0x87, 0x97, 0x1d, 0xf4, 0x73, 0xb8, 0x30, 0x86, 0x40, 0x9e,
-	0xe9, 0xc4, 0x82, 0x40, 0xf4, 0x52, 0x18, 0x88, 0x5c, 0xcb, 0xbe, 0xaf, 0x92, 0xdf, 0x31, 0x36,
-	0x76, 0x68, 0x31, 0x14, 0x64, 0x0c, 0x53, 0xbf, 0xfe, 0x35, 0x28, 0x0c, 0x31, 0xa1, 0xf5, 0x79,
-	0xa8, 0xdc, 0x5c, 0xe6, 0x8b, 0xa2, 0x88, 0x3d, 0x80, 0x97, 0xa6, 0x32, 0x07, 0xf4, 0x23, 0xc8,
-	0xfb, 0xa4, 0x23, 0x1e, 0x51, 0xb9, 0x79, 0xd5, 0x88, 0x2f, 0x2b, 0xff, 0x39, 0xee, 0x9b, 0x0c,
-	0xd7, 0x37, 0x75, 0xc8, 0x0c, 0xb1, 0x33, 0xea, 0xf3, 0x8a, 0xa3, 0xb8, 0xf5, 0xc6, 0x62, 0x9c,
-	0x83, 0xae, 0x8e, 0xfa, 0x44, 0x11, 0xca, 0xf2, 0x63, 0xc8, 0xf0, 0x15, 0xb4, 0x04, 0xd9, 0x87,
-	0xfb, 0xbb, 0xfb, 0xcd, 0x0f, 0xf7, 0xcb, 0x31, 0x04, 0x90, 0xd9, 0xae, 0xd5, 0xea, 0x07, 0xad,
-	0x72, 0x1c, 0xe5, 0x21, 0xbd, 0x5d, 0x6d, 0x2a, 0xad, 0x72, 0x82, 0x2e, 0x2b, 0xf5, 0xf7, 0xeb,
-	0xb5, 0x56, 0x39, 0x89, 0x56, 0xa0, 0xc0, 0xc7, 0xea, 0x83, 0xa6, 0xf2, 0xc1, 0x76, 0xab, 0x9c,
-	0x0a, 0x2c, 0x1d, 0xd6, 0xf7, 0xef, 0xd7, 0x95, 0x72, 0x5a, 0x7e, 0x93, 0x96, 0x34, 0x11, 0x2c,
-	0xc5, 0x2f, 0x5e, 0xe2, 0x81, 0xe2, 0x45, 0xfe, 0x63, 0x02, 0xa4, 0x68, 0xea, 0x81, 0xde, 0x1f,
-	0xdb, 0xf8, 0xd6, 0x19, 0x78, 0xcb, 0xd8, 0xee, 0xd1, 0x75, 0x28, 0x0e, 0xf1, 0x11, 0x26, 0x9d,
-	0x1e, 0xa7, 0x42, 0x3c, 0xb1, 0x15, 0x94, 0x82, 0x58, 0x65, 0x4a, 0x0e, 0x17, 0xfb, 0x04, 0x77,
-	0x88, 0xca, 0xeb, 0x28, 0x7e, 0xe8, 0xf2, 0x54, 0x8c, 0xae, 0x1e, 0xf2, 0x45, 0xf9, 0xe3, 0x33,
-	0xf9, 0x32, 0x0f, 0x69, 0xa5, 0xde, 0x52, 0x7e, 0x51, 0x4e, 0x22, 0x04, 0x45, 0x36, 0x54, 0x0f,
-	0xf7, 0xb7, 0x0f, 0x0e, 0x1b, 0x4d, 0xea, 0xcb, 0x73, 0x50, 0x72, 0x7d, 0xe9, 0x2e, 0xa6, 0xe5,
-	0xff, 0xc6, 0xa1, 0x34, 0x16, 0x20, 0x68, 0x0b, 0xd2, 0x9c, 0x4e, 0x47, 0x35, 0xdd, 0x59, 0x7c,
-	0x8b, 0x68, 0xe2, 0xa2, 0xe8, 0x6d, 0xc8, 0x61, 0xd1, 0x27, 0x98, 0x16, 0x88, 0xbc, 0xbf, 0xe1,
-	0x76, 0x12, 0x84, 0xaa, 0xa7, 0x81, 0xde, 0x81, 0xbc, 0x17, 0xe9, 0xa2, 0x86, 0x7b, 0x79, 0x52,
-	0xdd, 0xc3, 0x08, 0xa1, 0xef, 0xeb, 0xa0, 0x7b, 0x3e, 0x27, 0x4b, 0x4d, 0x92, 0x78, 0xa1, 0xce,
-	0x05, 0x84, 0xb2, 0x2b, 0x2f, 0xd7, 0x60, 0x29, 0xb0, 0x1f, 0x74, 0x09, 0xf2, 0x03, 0xed, 0x44,
-	0xf4, 0x9f, 0x78, 0x07, 0x21, 0x37, 0xd0, 0x4e, 0x78, 0xeb, 0xe9, 0x02, 0x64, 0xe9, 0xc3, 0xae,
-	0xc6, 0xd1, 0x26, 0xa9, 0x64, 0x06, 0xda, 0xc9, 0x7b, 0x9a, 0x23, 0x7f, 0x04, 0xc5, 0x70, 0xef,
-	0x85, 0x9e, 0xc4, 0xa1, 0x35, 0x32, 0x75, 0x66, 0x23, 0xad, 0xf0, 0x09, 0xba, 0x0d, 0xe9, 0x63,
-	0x8b, 0x83, 0xd5, 0xf4, 0x90, 0x7d, 0x64, 0x11, 0x1c, 0xe8, 0xdd, 0x70, 0x69, 0xf9, 0x33, 0x48,
-	0x33, 0xf0, 0xa1, 0x40, 0xc2, 0xba, 0x28, 0x82, 0x8f, 0xd2, 0x31, 0xfa, 0x08, 0x40, 0x23, 0x64,
-	0x68, 0xb4, 0x47, 0xbe, 0xe1, 0xf5, 0xe9, 0xe0, 0xb5, 0xed, 0xca, 0x55, 0x2f, 0x0b, 0x14, 0x5b,
-	0xf5, 0x55, 0x03, 0x48, 0x16, 0x30, 0x28, 0xef, 0x43, 0x31, 0xac, 0x1b, 0xec, 0x67, 0x2e, 0x4f,
-	0xe9, 0x67, 0x7a, 0x9c, 0xc7, 0x63, 0x4c, 0x49, 0xde, 0x31, 0x63, 0x13, 0xf9, 0x59, 0x1c, 0x72,
-	0xad, 0x13, 0x71, 0xac, 0x23, 0x9a, 0x35, 0xbe, 0x6a, 0x22, 0xd8, 0x9a, 0xe0, 0xdd, 0x9f, 0xa4,
-	0xd7, 0x53, 0x7a, 0xd7, 0x0b, 0xdc, 0xd4, 0xa2, 0xc5, 0xa3, 0xdb, 0x5c, 0x13, 0x60, 0xf5, 0x16,
-	0xe4, 0xbd, 0x53, 0x45, 0x89, 0xbd, 0xa6, 0xeb, 0x43, 0xec, 0x38, 0x62, 0x6f, 0xee, 0x94, 0xf5,
-	0xfe, 0xac, 0xa7, 0xa2, 0xf9, 0x91, 0x54, 0xf8, 0x44, 0xd6, 0xa1, 0x34, 0x96, 0xb6, 0xd0, 0x5b,
-	0x90, 0xb5, 0x47, 0x6d, 0xd5, 0x75, 0xcf, 0x58, 0xf0, 0xb8, 0x24, 0x6f, 0xd4, 0xee, 0x1b, 0x9d,
-	0x5d, 0x7c, 0xea, 0xfe, 0x18, 0x7b, 0xd4, 0xde, 0xe5, 0x5e, 0xe4, 0x6f, 0x49, 0x04, 0xdf, 0x72,
-	0x0c, 0x39, 0xf7, 0x50, 0xa0, 0x9f, 0x06, 0xe3, 0xc4, 0xed, 0x08, 0x47, 0xa6, 0x52, 0x61, 0x3e,
-	0x10, 0x26, 0x37, 0x61, 0xc5, 0x31, 0xba, 0x26, 0xd6, 0x55, 0xbf, 0xb4, 0x60, 0x6f, 0xcb, 0x29,
-	0x25, 0xfe, 0x60, 0xcf, 0xad, 0x2b, 0xe4, 0xff, 0xc4, 0x21, 0xe7, 0x06, 0x2c, 0x7a, 0x33, 0x70,
-	0xee, 0x8a, 0x53, 0x1a, 0x25, 0xae, 0xa0, 0xdf, 0xbe, 0x0b, 0xff, 0xd6, 0xc4, 0xd9, 0x7f, 0x6b,
-	0x54, 0x1f, 0xd6, 0x6d, 0x88, 0xa7, 0xce, 0xdc, 0x10, 0x7f, 0x1d, 0x10, 0xb1, 0x88, 0xd6, 0x57,
-	0x8f, 0x2d, 0x62, 0x98, 0x5d, 0x95, 0x3b, 0x9b, 0x33, 0xaa, 0x32, 0x7b, 0xf2, 0x88, 0x3d, 0x38,
-	0x60, 0x7e, 0xff, 0x4d, 0x1c, 0x72, 0x5e, 0x6e, 0x3c, 0x6b, 0x37, 0xee, 0x3c, 0x64, 0x04, 0xfc,
-	0xf3, 0x76, 0x9c, 0x98, 0x79, 0x8d, 0xe1, 0x54, 0xa0, 0x31, 0x2c, 0x41, 0x6e, 0x80, 0x89, 0xc6,
-	0x08, 0x02, 0xaf, 0xee, 0xbc, 0xf9, 0xcd, 0x7b, 0xb0, 0x14, 0x68, 0x8c, 0xd2, 0xc8, 0xdb, 0xaf,
-	0x7f, 0x58, 0x8e, 0x49, 0xd9, 0x67, 0x5f, 0x5e, 0x4d, 0xee, 0xe3, 0xa7, 0xf4, 0xcc, 0x2a, 0xf5,
-	0x5a, 0xa3, 0x5e, 0xdb, 0x2d, 0xc7, 0xa5, 0xa5, 0x67, 0x5f, 0x5e, 0xcd, 0x2a, 0x98, 0xf5, 0x57,
-	0x6e, 0x36, 0x60, 0x39, 0xf8, 0x55, 0xc2, 0x19, 0x04, 0x41, 0xf1, 0xfe, 0xc3, 0x83, 0xbd, 0x9d,
-	0xda, 0x76, 0xab, 0xae, 0x3e, 0x6a, 0xb6, 0xea, 0xe5, 0x38, 0xba, 0x00, 0xe7, 0xf6, 0x76, 0xde,
-	0x6b, 0xb4, 0xd4, 0xda, 0xde, 0x4e, 0x7d, 0xbf, 0xa5, 0x6e, 0xb7, 0x5a, 0xdb, 0xb5, 0xdd, 0x72,
-	0x62, 0xeb, 0x73, 0x80, 0xd2, 0x76, 0xb5, 0xb6, 0x43, 0xb3, 0x9f, 0xd1, 0xd1, 0x44, 0xff, 0x2a,
-	0xc5, 0x8a, 0xeb, 0x99, 0x37, 0xb2, 0xd2, 0xec, 0xf6, 0x1d, 0x7a, 0x00, 0x69, 0x56, 0x77, 0xa3,
-	0xd9, 0x57, 0xb4, 0xd2, 0x9c, 0x7e, 0x1e, 0xfd, 0x31, 0x2c, 0x3c, 0x66, 0xde, 0xd9, 0x4a, 0xb3,
-	0xdb, 0x7b, 0x48, 0x81, 0xbc, 0x5f, 0x38, 0xcf, 0xbf, 0xc3, 0x95, 0x16, 0x68, 0xf9, 0x51, 0x9b,
-	0x7e, 0x59, 0x30, 0xff, 0x4e, 0x53, 0x5a, 0x00, 0xc0, 0xd0, 0x1e, 0x64, 0xdd, 0x82, 0x6b, 0xde,
-	0x2d, 0xab, 0x34, 0xb7, 0x1d, 0x47, 0x3f, 0x01, 0x2f, 0x8c, 0x67, 0x5f, 0x19, 0x4b, 0x73, 0x7a,
-	0x8b, 0x68, 0x07, 0x32, 0x82, 0xeb, 0xce, 0xb9, 0x39, 0x95, 0xe6, 0xb5, 0xd7, 0xa8, 0xd3, 0xfc,
-	0x8e, 0xc3, 0xfc, 0x8b, 0x70, 0x69, 0x81, 0xb6, 0x29, 0x7a, 0x08, 0x10, 0x28, 0x83, 0x17, 0xb8,
-	0xe1, 0x96, 0x16, 0x69, 0x87, 0xa2, 0x26, 0xe4, 0xbc, 0x72, 0x67, 0xee, 0x7d, 0xb3, 0x34, 0xbf,
-	0x2f, 0x89, 0x1e, 0x43, 0x21, 0xcc, 0xf3, 0x17, 0xbb, 0x45, 0x96, 0x16, 0x6c, 0x38, 0x52, 0xfb,
-	0x61, 0xd2, 0xbf, 0xd8, 0xad, 0xb2, 0xb4, 0x60, 0xff, 0x11, 0x7d, 0x02, 0x2b, 0x93, 0xa4, 0x7c,
-	0xf1, 0x4b, 0x66, 0xe9, 0x0c, 0x1d, 0x49, 0x34, 0x00, 0x34, 0x85, 0xcc, 0x9f, 0xe1, 0xce, 0x59,
-	0x3a, 0x4b, 0x83, 0xb2, 0x5a, 0xff, 0xea, 0xf9, 0x5a, 0xfc, 0xeb, 0xe7, 0x6b, 0xf1, 0x7f, 0x3c,
-	0x5f, 0x8b, 0x7f, 0xf1, 0x62, 0x2d, 0xf6, 0xf5, 0x8b, 0xb5, 0xd8, 0xdf, 0x5e, 0xac, 0xc5, 0x7e,
-	0xf9, 0x5a, 0xd7, 0x20, 0xbd, 0x51, 0x7b, 0xa3, 0x63, 0x0d, 0x36, 0x83, 0x7f, 0x88, 0x99, 0xf6,
-	0x27, 0x9d, 0x76, 0x86, 0x25, 0xaa, 0x5b, 0xff, 0x0b, 0x00, 0x00, 0xff, 0xff, 0x3b, 0xae, 0x48,
-	0xb4, 0xc4, 0x23, 0x00, 0x00,
+	// 3145 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe4, 0x5a, 0xcd, 0x73, 0xdb, 0xc6,
+	0x15, 0x27, 0xf8, 0xcd, 0x47, 0x8a, 0xa2, 0x56, 0x8e, 0xc3, 0xc0, 0x8e, 0xe4, 0xc0, 0x93, 0x2f,
+	0x27, 0x91, 0x12, 0x79, 0x9c, 0x38, 0x1f, 0x4d, 0x22, 0xd1, 0x94, 0xa9, 0x58, 0x91, 0x14, 0x88,
+	0xb6, 0x9b, 0xb6, 0x31, 0x02, 0x92, 0x2b, 0x12, 0x31, 0x09, 0x20, 0x00, 0x28, 0x4b, 0x39, 0xf6,
+	0x63, 0xda, 0x49, 0x2f, 0x39, 0xf4, 0xd0, 0xe9, 0x4c, 0x0e, 0xfd, 0x2f, 0x7a, 0xea, 0x25, 0x97,
+	0xcc, 0xf4, 0x92, 0x63, 0x4f, 0x69, 0x26, 0xbe, 0xf5, 0x1f, 0xe8, 0xa5, 0x9d, 0x76, 0xf6, 0x03,
+	0xc0, 0x82, 0x24, 0x48, 0xca, 0xc9, 0xad, 0x37, 0xbc, 0xdd, 0xf7, 0xde, 0x62, 0xdf, 0xee, 0xbe,
+	0xf7, 0x7b, 0x6f, 0x17, 0x2e, 0x78, 0xd8, 0xec, 0x60, 0x67, 0x60, 0x98, 0xde, 0xba, 0xde, 0x6a,
+	0x1b, 0xeb, 0xde, 0xa9, 0x8d, 0xdd, 0x35, 0xdb, 0xb1, 0x3c, 0x0b, 0x2d, 0x86, 0x9d, 0x6b, 0xa4,
+	0x53, 0x7e, 0x52, 0xe0, 0x6e, 0x3b, 0xa7, 0xb6, 0x67, 0xad, 0xdb, 0x8e, 0x65, 0x1d, 0x31, 0x7e,
+	0xf9, 0xa2, 0xd0, 0x4d, 0xf5, 0x88, 0xda, 0x22, 0xbd, 0x5c, 0xf8, 0x3e, 0x3e, 0xf5, 0x7b, 0x9f,
+	0x1c, 0x93, 0xb5, 0x75, 0x47, 0x1f, 0xf8, 0xdd, 0xab, 0x5d, 0xcb, 0xea, 0xf6, 0xf1, 0x3a, 0xa5,
+	0x5a, 0xc3, 0xa3, 0x75, 0xcf, 0x18, 0x60, 0xd7, 0xd3, 0x07, 0x36, 0x67, 0x38, 0xd7, 0xb5, 0xba,
+	0x16, 0xfd, 0x5c, 0x27, 0x5f, 0xac, 0x55, 0xf9, 0x0a, 0x20, 0xa7, 0xe2, 0x4f, 0x87, 0xd8, 0xf5,
+	0xd0, 0x06, 0xa4, 0x71, 0xbb, 0x67, 0x55, 0xa5, 0x4b, 0xd2, 0x73, 0xc5, 0x8d, 0x8b, 0x6b, 0x23,
+	0x93, 0x5b, 0xe3, 0x7c, 0xf5, 0x76, 0xcf, 0x6a, 0x24, 0x54, 0xca, 0x8b, 0xae, 0x41, 0xe6, 0xa8,
+	0x3f, 0x74, 0x7b, 0xd5, 0x24, 0x15, 0x7a, 0x32, 0x4e, 0x68, 0x9b, 0x30, 0x35, 0x12, 0x2a, 0xe3,
+	0x26, 0x43, 0x19, 0xe6, 0x91, 0x55, 0x4d, 0x4d, 0x1f, 0x6a, 0xc7, 0x3c, 0xa2, 0x43, 0x11, 0x5e,
+	0xb4, 0x05, 0xe0, 0x62, 0x4f, 0xb3, 0x6c, 0xcf, 0xb0, 0xcc, 0x6a, 0x9a, 0x4a, 0x3e, 0x15, 0x27,
+	0x79, 0x88, 0xbd, 0x7d, 0xca, 0xd8, 0x48, 0xa8, 0x05, 0xd7, 0x27, 0x88, 0x0e, 0xc3, 0x34, 0x3c,
+	0xad, 0xdd, 0xd3, 0x0d, 0xb3, 0x9a, 0x99, 0xae, 0x63, 0xc7, 0x34, 0xbc, 0x1a, 0x61, 0x24, 0x3a,
+	0x0c, 0x9f, 0x20, 0x53, 0xfe, 0x74, 0x88, 0x9d, 0xd3, 0x6a, 0x76, 0xfa, 0x94, 0x3f, 0x20, 0x4c,
+	0x64, 0xca, 0x94, 0x1b, 0xd5, 0xa1, 0xd8, 0xc2, 0x5d, 0xc3, 0xd4, 0x5a, 0x7d, 0xab, 0x7d, 0xbf,
+	0x9a, 0xa3, 0xc2, 0x4a, 0x9c, 0xf0, 0x16, 0x61, 0xdd, 0x22, 0x9c, 0x8d, 0x84, 0x0a, 0xad, 0x80,
+	0x42, 0x6f, 0x41, 0xbe, 0xdd, 0xc3, 0xed, 0xfb, 0x9a, 0x77, 0x52, 0xcd, 0x53, 0x1d, 0xab, 0x71,
+	0x3a, 0x6a, 0x84, 0xaf, 0x79, 0xd2, 0x48, 0xa8, 0xb9, 0x36, 0xfb, 0x24, 0xf3, 0xef, 0xe0, 0xbe,
+	0x71, 0x8c, 0x1d, 0x22, 0x5f, 0x98, 0x3e, 0xff, 0x1b, 0x8c, 0x93, 0x6a, 0x28, 0x74, 0x7c, 0x02,
+	0xbd, 0x03, 0x05, 0x6c, 0x76, 0xf8, 0x34, 0x80, 0xaa, 0xb8, 0x14, 0xbb, 0x57, 0xcc, 0x8e, 0x3f,
+	0x89, 0x3c, 0xe6, 0xdf, 0xe8, 0x3a, 0x64, 0xdb, 0xd6, 0x60, 0x60, 0x78, 0xd5, 0x22, 0x95, 0x5e,
+	0x89, 0x9d, 0x00, 0xe5, 0x6a, 0x24, 0x54, 0xce, 0x8f, 0xf6, 0xa0, 0xdc, 0x37, 0x5c, 0x4f, 0x73,
+	0x4d, 0xdd, 0x76, 0x7b, 0x96, 0xe7, 0x56, 0x4b, 0x54, 0xc3, 0xd3, 0x71, 0x1a, 0x76, 0x0d, 0xd7,
+	0x3b, 0xf4, 0x99, 0x1b, 0x09, 0x75, 0xa1, 0x2f, 0x36, 0x10, 0x7d, 0xd6, 0xd1, 0x11, 0x76, 0x02,
+	0x85, 0xd5, 0x85, 0xe9, 0xfa, 0xf6, 0x09, 0xb7, 0x2f, 0x4f, 0xf4, 0x59, 0x62, 0x03, 0xfa, 0x39,
+	0x2c, 0xf7, 0x2d, 0xbd, 0x13, 0xa8, 0xd3, 0xda, 0xbd, 0xa1, 0x79, 0xbf, 0x5a, 0xa6, 0x4a, 0x9f,
+	0x8f, 0xfd, 0x49, 0x4b, 0xef, 0xf8, 0x2a, 0x6a, 0x44, 0xa0, 0x91, 0x50, 0x97, 0xfa, 0xa3, 0x8d,
+	0xe8, 0x1e, 0x9c, 0xd3, 0x6d, 0xbb, 0x7f, 0x3a, 0xaa, 0x7d, 0x91, 0x6a, 0xbf, 0x12, 0xa7, 0x7d,
+	0x93, 0xc8, 0x8c, 0xaa, 0x47, 0xfa, 0x58, 0x2b, 0xda, 0x86, 0x52, 0x17, 0x7b, 0x9a, 0x6e, 0xdb,
+	0x5a, 0x4f, 0x77, 0x7b, 0xd5, 0xca, 0xf4, 0x1d, 0x7a, 0x13, 0x13, 0xd5, 0x0d, 0x9d, 0x1e, 0x6b,
+	0xe8, 0x06, 0x14, 0xf9, 0xcf, 0x2e, 0x36, 0xb1, 0xa3, 0x7b, 0x58, 0x3b, 0x72, 0xf4, 0x61, 0x47,
+	0xa3, 0x2e, 0xb0, 0xba, 0x34, 0xfd, 0x3f, 0x6f, 0x72, 0x99, 0x6d, 0x22, 0x72, 0x40, 0x24, 0xc8,
+	0x7f, 0x76, 0xc7, 0x5a, 0xd1, 0x6f, 0x25, 0xb8, 0xec, 0x39, 0x46, 0xb7, 0x8b, 0x1d, 0x51, 0xbf,
+	0xc6, 0x59, 0x0d, 0xcb, 0xd4, 0x06, 0x56, 0x07, 0x57, 0x11, 0x1d, 0xef, 0xb5, 0xb8, 0xf1, 0x9a,
+	0x4c, 0x45, 0xa8, 0xf8, 0x66, 0x20, 0xff, 0xbe, 0xd5, 0xc1, 0x8d, 0x84, 0xba, 0xea, 0x4d, 0x67,
+	0xd9, 0xca, 0x41, 0xe6, 0x58, 0xef, 0x0f, 0xb1, 0xf2, 0x2c, 0x14, 0x05, 0xe7, 0x88, 0xaa, 0x90,
+	0x1b, 0x60, 0xd7, 0xd5, 0xbb, 0x98, 0xfa, 0xd2, 0x82, 0xea, 0x93, 0x4a, 0x19, 0x4a, 0xa2, 0x43,
+	0x54, 0x06, 0x81, 0x20, 0x71, 0x75, 0x44, 0xf0, 0x18, 0x3b, 0x2e, 0xf1, 0x6f, 0x5c, 0x90, 0x93,
+	0xe8, 0x32, 0x2c, 0xd0, 0x03, 0xa7, 0xf9, 0xfd, 0xc4, 0xdf, 0xa6, 0xd5, 0x12, 0x6d, 0xbc, 0xc3,
+	0x99, 0x56, 0xa1, 0x68, 0x6f, 0xd8, 0x01, 0x4b, 0x8a, 0xb2, 0x80, 0xbd, 0x61, 0x73, 0x06, 0xe5,
+	0x0d, 0xa8, 0x8c, 0xfa, 0x47, 0x54, 0x81, 0xd4, 0x7d, 0x7c, 0xca, 0xc7, 0x23, 0x9f, 0xe8, 0x1c,
+	0x9f, 0x16, 0x1d, 0xa3, 0xa0, 0xf2, 0x39, 0xfe, 0x2d, 0x19, 0x08, 0x07, 0x8e, 0x11, 0x5d, 0x87,
+	0x34, 0x89, 0x33, 0x3c, 0x64, 0xc8, 0x6b, 0x2c, 0x08, 0xad, 0xf9, 0x41, 0x68, 0xad, 0xe9, 0x07,
+	0xa1, 0xad, 0xfc, 0xd7, 0xdf, 0xae, 0x26, 0xbe, 0xf8, 0xc7, 0xaa, 0xa4, 0x52, 0x09, 0xf4, 0x04,
+	0xf1, 0x63, 0xba, 0x61, 0x6a, 0x46, 0x87, 0x8f, 0x93, 0xa3, 0xf4, 0x4e, 0x07, 0xdd, 0x82, 0x4a,
+	0xdb, 0x32, 0x5d, 0x6c, 0xba, 0x43, 0x57, 0x63, 0x41, 0x8e, 0x07, 0x8a, 0x71, 0x3f, 0x53, 0xf3,
+	0x19, 0x0f, 0x28, 0x9f, 0xba, 0xd8, 0x8e, 0x36, 0xa0, 0x6d, 0x80, 0x63, 0xbd, 0x6f, 0x74, 0x74,
+	0xcf, 0x72, 0xdc, 0x6a, 0xfa, 0x52, 0x6a, 0xa2, 0x9a, 0x3b, 0x3e, 0xcb, 0x6d, 0xbb, 0xa3, 0x7b,
+	0x78, 0x2b, 0x4d, 0xfe, 0x56, 0x15, 0x24, 0xd1, 0x33, 0xb0, 0x48, 0x4e, 0x86, 0xeb, 0x91, 0x6d,
+	0xdd, 0x3a, 0xf5, 0xb0, 0x4b, 0xc3, 0x47, 0x49, 0x5d, 0xd0, 0x6d, 0xfb, 0x90, 0xb4, 0x6e, 0x91,
+	0x46, 0xf4, 0x34, 0x94, 0x49, 0xa8, 0x30, 0xf4, 0xbe, 0xd6, 0xc3, 0x46, 0xb7, 0xe7, 0xd1, 0x30,
+	0x91, 0x52, 0x17, 0x78, 0x6b, 0x83, 0x36, 0x2a, 0x9d, 0x60, 0x23, 0xd0, 0x30, 0x81, 0x10, 0xa4,
+	0x3b, 0xba, 0xa7, 0x53, 0x43, 0x96, 0x54, 0xfa, 0x4d, 0xda, 0x6c, 0xdd, 0xeb, 0x71, 0xf3, 0xd0,
+	0x6f, 0x74, 0x1e, 0xb2, 0x5c, 0x6d, 0x8a, 0xaa, 0xe5, 0x14, 0x59, 0x33, 0xdb, 0xb1, 0x8e, 0x31,
+	0x8d, 0x8b, 0x79, 0x95, 0x11, 0xca, 0xaf, 0x93, 0xb0, 0x34, 0x16, 0x50, 0x88, 0x5e, 0x7a, 0xc0,
+	0xf9, 0x58, 0xe4, 0x1b, 0xbd, 0x4a, 0xf4, 0xea, 0x1d, 0xec, 0xf0, 0x40, 0x5e, 0x15, 0x4d, 0xc4,
+	0x40, 0x4a, 0x83, 0xf6, 0x73, 0xd3, 0x70, 0x6e, 0xb4, 0x0f, 0x95, 0xbe, 0xee, 0x7a, 0x1a, 0x73,
+	0xd0, 0x9a, 0x10, 0xd4, 0xc7, 0xc3, 0xd2, 0xae, 0xee, 0xbb, 0x74, 0xb2, 0xd9, 0xb9, 0xa2, 0x72,
+	0x3f, 0xd2, 0x8a, 0x54, 0x38, 0xd7, 0x3a, 0xfd, 0x4c, 0x37, 0x3d, 0xc3, 0xc4, 0xda, 0xd8, 0xca,
+	0x3d, 0x31, 0xa6, 0xb4, 0x7e, 0x6c, 0x74, 0xb0, 0xd9, 0xf6, 0x97, 0x6c, 0x39, 0x10, 0x0e, 0x96,
+	0xd4, 0x55, 0x54, 0x28, 0x47, 0x43, 0x22, 0x2a, 0x43, 0xd2, 0x3b, 0xe1, 0x06, 0x48, 0x7a, 0x27,
+	0xe8, 0x65, 0x48, 0x93, 0x49, 0xd2, 0xc9, 0x97, 0x27, 0xe0, 0x11, 0x2e, 0xd7, 0x3c, 0xb5, 0xb1,
+	0x4a, 0x39, 0x15, 0x25, 0x38, 0x0d, 0x41, 0x98, 0x1c, 0xd5, 0xaa, 0x3c, 0x0f, 0x8b, 0x23, 0x71,
+	0x50, 0x58, 0x3f, 0x49, 0x5c, 0x3f, 0x65, 0x11, 0x16, 0x22, 0x41, 0x4f, 0x39, 0x0f, 0xe7, 0x26,
+	0xc5, 0x30, 0xa5, 0x17, 0xb4, 0x47, 0x62, 0x11, 0xba, 0x06, 0xf9, 0x20, 0x88, 0xb1, 0xd3, 0x38,
+	0x6e, 0x2b, 0x9f, 0x59, 0x0d, 0x58, 0xc9, 0x31, 0x0c, 0x1c, 0x7e, 0x92, 0xfe, 0x78, 0x4e, 0x67,
+	0x7e, 0x5c, 0xf9, 0x18, 0xaa, 0x71, 0x01, 0x6a, 0x64, 0x1a, 0xe9, 0x60, 0x1b, 0x9e, 0x87, 0xec,
+	0x91, 0xe5, 0x0c, 0x74, 0x8f, 0x2a, 0x5b, 0x50, 0x39, 0x45, 0xb6, 0x27, 0x0b, 0x56, 0x29, 0xda,
+	0xcc, 0x08, 0x45, 0x83, 0x27, 0x62, 0x83, 0x14, 0x11, 0x31, 0xcc, 0x0e, 0x66, 0xf6, 0x5c, 0x50,
+	0x19, 0x11, 0x2a, 0x62, 0x3f, 0xcb, 0x08, 0x32, 0xac, 0x4b, 0xe7, 0x4a, 0xf5, 0x17, 0x54, 0x4e,
+	0x29, 0xcb, 0xc1, 0xf6, 0x0f, 0xa3, 0x95, 0x72, 0x21, 0x18, 0x75, 0x3c, 0xe4, 0x28, 0xcf, 0xc1,
+	0x33, 0xf3, 0xc5, 0x07, 0xe5, 0x4f, 0x45, 0xc8, 0xab, 0xd8, 0xb5, 0x89, 0xbf, 0x41, 0x5b, 0x50,
+	0xc0, 0x27, 0x6d, 0xcc, 0xa0, 0xa9, 0x14, 0x1b, 0x38, 0x19, 0x77, 0xdd, 0xe7, 0x24, 0xb8, 0x2a,
+	0x10, 0x43, 0x57, 0x39, 0xfc, 0x8e, 0x47, 0xd2, 0x5c, 0x5c, 0xc4, 0xdf, 0xaf, 0xfa, 0xf8, 0x3b,
+	0x15, 0x0b, 0xa5, 0x98, 0xd4, 0x08, 0x00, 0xbf, 0xca, 0x01, 0x78, 0x7a, 0xc6, 0x60, 0x11, 0x04,
+	0x5e, 0x8b, 0x20, 0xf0, 0xcc, 0x8c, 0x69, 0xc6, 0x40, 0xf0, 0x5a, 0x04, 0x82, 0x67, 0x67, 0x28,
+	0x89, 0xc1, 0xe0, 0xaf, 0xfa, 0x18, 0x3c, 0x37, 0x63, 0xda, 0x23, 0x20, 0x7c, 0x3b, 0x0a, 0xc2,
+	0x19, 0x80, 0xbe, 0x1c, 0x2b, 0x1d, 0x8b, 0xc2, 0x7f, 0x22, 0xa0, 0xf0, 0x42, 0x2c, 0x04, 0x66,
+	0x4a, 0x26, 0xc0, 0xf0, 0x5a, 0x04, 0x86, 0xc3, 0x0c, 0x1b, 0xc4, 0xe0, 0xf0, 0x77, 0x45, 0x1c,
+	0x5e, 0x8c, 0x85, 0xf2, 0x7c, 0xd3, 0x4c, 0x02, 0xe2, 0xaf, 0x07, 0x40, 0xbc, 0x14, 0x9b, 0x49,
+	0xf0, 0x39, 0x8c, 0x22, 0xf1, 0xfd, 0x31, 0x24, 0xce, 0x90, 0xf3, 0x33, 0xb1, 0x2a, 0x66, 0x40,
+	0xf1, 0xfd, 0x31, 0x28, 0x5e, 0x9e, 0xa1, 0x70, 0x06, 0x16, 0xff, 0xc5, 0x64, 0x2c, 0x1e, 0x8f,
+	0x96, 0xf9, 0x6f, 0xce, 0x07, 0xc6, 0xb5, 0x18, 0x30, 0xce, 0x40, 0xf3, 0x0b, 0xb1, 0xea, 0xe7,
+	0x46, 0xe3, 0x37, 0x47, 0xd0, 0xf8, 0xd2, 0x8c, 0xad, 0x1a, 0x0b, 0xc7, 0xb5, 0x18, 0x38, 0x8e,
+	0x66, 0xfc, 0xe9, 0xdc, 0x78, 0xfc, 0x77, 0x73, 0xe2, 0xf1, 0x65, 0x3a, 0xe0, 0xf5, 0xd8, 0x01,
+	0x7f, 0x4c, 0x40, 0xfe, 0x3c, 0x71, 0xfc, 0x23, 0xde, 0x96, 0xc4, 0x0e, 0xec, 0x38, 0x96, 0xc3,
+	0xb1, 0x2e, 0x23, 0x94, 0xe7, 0x08, 0x12, 0x0b, 0x3d, 0xeb, 0x14, 0xf0, 0x4e, 0x63, 0xb4, 0xe0,
+	0x4d, 0x95, 0xbf, 0x48, 0xa1, 0x2c, 0x05, 0x2f, 0x22, 0x8a, 0x2b, 0x70, 0x14, 0x27, 0x60, 0xfa,
+	0x64, 0x14, 0xd3, 0xaf, 0x42, 0x91, 0x2c, 0xef, 0x08, 0x5c, 0xd7, 0x6d, 0x1f, 0xae, 0xa3, 0x2b,
+	0xb0, 0x44, 0xc1, 0x15, 0x43, 0xfe, 0x3c, 0xe0, 0xa6, 0x29, 0x6e, 0x58, 0x24, 0x1d, 0xec, 0x44,
+	0xb3, 0xc8, 0xfb, 0x12, 0x2c, 0x0b, 0xbc, 0xc1, 0xb6, 0x61, 0x18, 0xb5, 0x12, 0x70, 0xfb, 0x41,
+	0xf0, 0xfd, 0xd0, 0x40, 0x61, 0x2a, 0x80, 0x20, 0xdd, 0x26, 0x2b, 0xc5, 0x22, 0x2e, 0xfd, 0x26,
+	0xe9, 0x41, 0xdf, 0xea, 0xf2, 0xb8, 0x4a, 0x3e, 0x09, 0x57, 0x10, 0x3a, 0x0a, 0x2c, 0x32, 0x28,
+	0x5f, 0x49, 0xa1, 0xbe, 0x30, 0x3b, 0x98, 0x04, 0xe4, 0xa5, 0x1f, 0x07, 0xc8, 0x27, 0x1f, 0x19,
+	0xc8, 0x8b, 0x88, 0x27, 0x15, 0x45, 0x3c, 0xff, 0x92, 0xc2, 0x15, 0x0e, 0x60, 0xf9, 0xa3, 0x59,
+	0x24, 0x84, 0x2f, 0x19, 0xba, 0x5e, 0x1c, 0xbe, 0xf0, 0x64, 0x2b, 0x4b, 0xc7, 0x8d, 0x26, 0x5b,
+	0x39, 0x06, 0x68, 0x28, 0x81, 0xae, 0x43, 0x81, 0x1d, 0x22, 0xcb, 0x76, 0x79, 0x94, 0xba, 0x20,
+	0xce, 0x95, 0x95, 0x07, 0xd7, 0xe8, 0x19, 0xd8, 0xb7, 0x5d, 0x35, 0x6f, 0xf3, 0x2f, 0x01, 0x99,
+	0x15, 0x22, 0x09, 0xc2, 0x45, 0x28, 0x90, 0xbf, 0x77, 0x6d, 0xbd, 0x8d, 0x69, 0xc4, 0x29, 0xa8,
+	0x61, 0x83, 0x72, 0x0f, 0xd0, 0x78, 0xcc, 0x43, 0x0d, 0xc8, 0xe2, 0x63, 0x6c, 0x7a, 0x64, 0xd5,
+	0x88, 0xb9, 0xcf, 0x4f, 0x40, 0xdf, 0xd8, 0xf4, 0xb6, 0xaa, 0xc4, 0xc8, 0xff, 0xfc, 0x76, 0xb5,
+	0xc2, 0xb8, 0x5f, 0xb4, 0x06, 0x86, 0x87, 0x07, 0xb6, 0x77, 0xaa, 0x72, 0x79, 0xe5, 0x57, 0x49,
+	0x02, 0x85, 0x23, 0xf1, 0x70, 0xa2, 0x6d, 0xfd, 0x03, 0x94, 0x14, 0xd2, 0xa0, 0xf9, 0xec, 0xbd,
+	0x02, 0xd0, 0xd5, 0x5d, 0xed, 0x81, 0x6e, 0x7a, 0xb8, 0xc3, 0x8d, 0x2e, 0xb4, 0x20, 0x19, 0xf2,
+	0x84, 0x1a, 0xba, 0xb8, 0xc3, 0x33, 0xb2, 0x80, 0x16, 0xe6, 0x99, 0xfb, 0x61, 0xf3, 0x8c, 0x5a,
+	0x39, 0x3f, 0x6a, 0xe5, 0xdf, 0x24, 0xc3, 0x53, 0x12, 0x66, 0x0d, 0xff, 0x7f, 0x76, 0xf8, 0x3d,
+	0x2d, 0x25, 0x44, 0x81, 0x09, 0x3a, 0x84, 0xa5, 0xe0, 0x94, 0x6a, 0x43, 0x7a, 0x7a, 0xfd, 0x7d,
+	0x37, 0xef, 0x31, 0xaf, 0x1c, 0x47, 0x9b, 0x5d, 0xf4, 0x53, 0x78, 0x7c, 0xc4, 0x03, 0x05, 0xaa,
+	0x93, 0x73, 0x3a, 0xa2, 0xc7, 0xa2, 0x8e, 0xc8, 0xd7, 0x1c, 0xda, 0x2a, 0xf5, 0x03, 0xcf, 0xc6,
+	0x0e, 0xc9, 0x4e, 0x45, 0x98, 0x35, 0x71, 0xf5, 0x2f, 0xc3, 0x82, 0x83, 0x3d, 0xdd, 0x30, 0xb5,
+	0x48, 0xfe, 0x5f, 0x62, 0x8d, 0xbc, 0xaa, 0x70, 0x00, 0x8f, 0x4d, 0x84, 0x5b, 0xe8, 0x35, 0x28,
+	0x84, 0x48, 0x4d, 0x8a, 0x49, 0xa5, 0x83, 0xf4, 0x30, 0xe4, 0x55, 0xfe, 0x2a, 0x85, 0x2a, 0xa3,
+	0x09, 0x67, 0x1d, 0xb2, 0x0e, 0x76, 0x87, 0x7d, 0x96, 0x02, 0x96, 0x37, 0x5e, 0x9a, 0x0f, 0xa8,
+	0x91, 0xd6, 0x61, 0xdf, 0x53, 0xb9, 0xb0, 0x72, 0x0f, 0xb2, 0xac, 0x05, 0x15, 0x21, 0x77, 0x7b,
+	0xef, 0xd6, 0xde, 0xfe, 0xdd, 0xbd, 0x4a, 0x02, 0x01, 0x64, 0x37, 0x6b, 0xb5, 0xfa, 0x41, 0xb3,
+	0x22, 0xa1, 0x02, 0x64, 0x36, 0xb7, 0xf6, 0xd5, 0x66, 0x25, 0x49, 0x9a, 0xd5, 0xfa, 0x7b, 0xf5,
+	0x5a, 0xb3, 0x92, 0x42, 0x4b, 0xb0, 0xc0, 0xbe, 0xb5, 0xed, 0x7d, 0xf5, 0xfd, 0xcd, 0x66, 0x25,
+	0x2d, 0x34, 0x1d, 0xd6, 0xf7, 0x6e, 0xd4, 0xd5, 0x4a, 0x46, 0x79, 0x85, 0x64, 0x7b, 0x31, 0xd0,
+	0x2e, 0xcc, 0x26, 0x25, 0x21, 0x9b, 0x54, 0xfe, 0x98, 0x04, 0x39, 0x1e, 0xaf, 0xa1, 0xf7, 0x46,
+	0x26, 0xbe, 0x71, 0x06, 0xb0, 0x37, 0x32, 0x7b, 0xf4, 0x34, 0x94, 0x1d, 0x7c, 0x84, 0xbd, 0x76,
+	0x8f, 0xe1, 0x47, 0x16, 0xd8, 0x16, 0xd4, 0x05, 0xde, 0x4a, 0x85, 0x5c, 0xc6, 0xf6, 0x09, 0x6e,
+	0x7b, 0x1a, 0x4b, 0x6c, 0xd9, 0xa6, 0x2b, 0x10, 0x36, 0xd2, 0x7a, 0xc8, 0x1a, 0x95, 0x8f, 0xcf,
+	0x64, 0xcb, 0x02, 0x64, 0xd4, 0x7a, 0x53, 0xfd, 0xb0, 0x92, 0x42, 0x08, 0xca, 0xf4, 0x53, 0x3b,
+	0xdc, 0xdb, 0x3c, 0x38, 0x6c, 0xec, 0x13, 0x5b, 0x2e, 0xc3, 0xa2, 0x6f, 0x4b, 0xbf, 0x31, 0xa3,
+	0xac, 0x87, 0x71, 0x22, 0x04, 0x9c, 0x91, 0x90, 0x2a, 0x45, 0x43, 0xea, 0x87, 0xa1, 0x29, 0xc7,
+	0x01, 0x25, 0x7a, 0x13, 0xe0, 0x28, 0xa0, 0x38, 0x34, 0xb8, 0x30, 0x66, 0xce, 0x50, 0x40, 0x15,
+	0xd8, 0x95, 0x1a, 0x3c, 0x3b, 0x27, 0x74, 0x24, 0x18, 0xcc, 0x1d, 0xb6, 0xdb, 0xd8, 0x65, 0xf8,
+	0x23, 0xaf, 0xfa, 0xa4, 0xf2, 0x5f, 0x09, 0x16, 0x47, 0x4e, 0x3c, 0xda, 0x80, 0x0c, 0x4b, 0xaa,
+	0xe2, 0x2e, 0xc2, 0xa8, 0xc3, 0xe2, 0xee, 0x81, 0xb1, 0xa2, 0xb7, 0x20, 0x8f, 0x79, 0x25, 0x6a,
+	0x92, 0x67, 0x61, 0x15, 0x34, 0xbf, 0x56, 0xc5, 0x45, 0x03, 0x09, 0xf4, 0x0e, 0x14, 0x02, 0xd7,
+	0xc5, 0x33, 0xf9, 0xa7, 0xc6, 0xc5, 0x03, 0xa7, 0xc7, 0xe5, 0x43, 0x19, 0xf4, 0x7a, 0x08, 0x32,
+	0xd3, 0xe3, 0xa9, 0x1c, 0x17, 0x67, 0x0c, 0x5c, 0xd8, 0xe7, 0x57, 0x6a, 0x50, 0x14, 0xe6, 0x83,
+	0x2e, 0x40, 0x61, 0xa0, 0x9f, 0xf0, 0x0a, 0x27, 0xab, 0x51, 0xe5, 0x07, 0xfa, 0x09, 0x2b, 0x6e,
+	0x3e, 0x0e, 0x39, 0xd2, 0xd9, 0xd5, 0x99, 0xfb, 0x4c, 0xa9, 0xd9, 0x81, 0x7e, 0x72, 0x53, 0x77,
+	0x95, 0x8f, 0xa0, 0x1c, 0xad, 0xee, 0x91, 0xa3, 0xe5, 0x58, 0x43, 0xb3, 0x43, 0x75, 0x64, 0x54,
+	0x46, 0xa0, 0x6b, 0x90, 0x39, 0xb6, 0x98, 0xf7, 0x9d, 0xec, 0x83, 0xee, 0x58, 0x1e, 0x16, 0xaa,
+	0x83, 0x8c, 0x5b, 0xf9, 0x0c, 0x32, 0xd4, 0x9b, 0x12, 0xcf, 0x48, 0xeb, 0x74, 0x1c, 0x60, 0x93,
+	0x6f, 0xf4, 0x11, 0x80, 0xee, 0x79, 0x8e, 0xd1, 0x1a, 0x86, 0x8a, 0x57, 0x27, 0x7b, 0xe3, 0x4d,
+	0x9f, 0x6f, 0xeb, 0x22, 0x77, 0xcb, 0xe7, 0x42, 0x51, 0xc1, 0x35, 0x0b, 0x0a, 0x95, 0x3d, 0x28,
+	0x47, 0x65, 0xc5, 0x8a, 0x79, 0x69, 0x42, 0xc5, 0x3c, 0x00, 0x71, 0x01, 0x04, 0x4c, 0xb1, 0x9a,
+	0x2c, 0x25, 0x94, 0xcf, 0x25, 0xc8, 0x37, 0x4f, 0xf8, 0x39, 0x8d, 0x29, 0x07, 0x86, 0xa2, 0x49,
+	0xb1, 0xf8, 0xc5, 0xea, 0x8b, 0xa9, 0xa0, 0x6a, 0xf9, 0x6e, 0xe0, 0x89, 0xd2, 0xf3, 0x96, 0x10,
+	0xfc, 0xf2, 0x2d, 0xf7, 0xbe, 0x6f, 0x42, 0x21, 0xd8, 0x55, 0xe4, 0x94, 0xe8, 0x9d, 0x8e, 0xe3,
+	0x9f, 0x12, 0x72, 0x8a, 0x19, 0x49, 0xab, 0xcb, 0xd6, 0x03, 0x5e, 0x5e, 0x4b, 0xa9, 0x8c, 0x50,
+	0x3a, 0xb0, 0x38, 0x12, 0x87, 0xd1, 0x9b, 0x90, 0xb3, 0x87, 0x2d, 0xcd, 0x37, 0xcf, 0xc8, 0xe1,
+	0xf1, 0x51, 0xeb, 0xb0, 0xd5, 0x37, 0xda, 0xb7, 0xf0, 0xa9, 0xff, 0x33, 0xf6, 0xb0, 0x75, 0x8b,
+	0x59, 0x91, 0x8d, 0x92, 0x14, 0x47, 0x39, 0x86, 0xbc, 0xbf, 0x29, 0xd0, 0xdb, 0xe2, 0x39, 0xf1,
+	0xef, 0x1c, 0x62, 0xb1, 0x01, 0x57, 0x2f, 0x1c, 0x93, 0x2b, 0xb0, 0xe4, 0x1a, 0x5d, 0x13, 0x77,
+	0xb4, 0x30, 0x57, 0xa2, 0xa3, 0xe5, 0xd5, 0x45, 0xd6, 0xb1, 0xeb, 0x27, 0x4a, 0xca, 0x7f, 0x24,
+	0xc8, 0xfb, 0x07, 0x16, 0xbd, 0x22, 0xec, 0xbb, 0xf2, 0x84, 0x72, 0x99, 0xcf, 0x18, 0x16, 0x88,
+	0xa3, 0xff, 0x9a, 0x3c, 0xfb, 0xbf, 0xc6, 0x55, 0xfa, 0xfd, 0x2b, 0x97, 0xf4, 0x99, 0xaf, 0x5c,
+	0x5e, 0x04, 0xe4, 0x59, 0x9e, 0xde, 0xd7, 0x8e, 0x2d, 0xcf, 0x30, 0xbb, 0x1a, 0x33, 0x36, 0x83,
+	0x88, 0x15, 0xda, 0x73, 0x87, 0x76, 0x1c, 0x50, 0xbb, 0xff, 0x52, 0x82, 0x7c, 0x10, 0xec, 0xcf,
+	0x5a, 0xef, 0x3d, 0x0f, 0x59, 0x1e, 0xcf, 0x58, 0xc1, 0x97, 0x53, 0xc1, 0xd5, 0x43, 0x5a, 0xb8,
+	0x7a, 0x90, 0x21, 0x3f, 0xc0, 0x9e, 0x4e, 0x11, 0x0f, 0x4b, 0x57, 0x03, 0x5a, 0xf9, 0xb7, 0x04,
+	0x20, 0xc4, 0x8b, 0xa7, 0xa0, 0x14, 0xc9, 0x85, 0xd9, 0xa1, 0x29, 0xb6, 0x84, 0x3c, 0x98, 0x6c,
+	0x62, 0x16, 0x7b, 0x46, 0xea, 0xd9, 0xe8, 0x03, 0x28, 0xd1, 0xdb, 0x9b, 0xbb, 0x86, 0x67, 0x92,
+	0x3d, 0xce, 0x70, 0xdb, 0x4b, 0x53, 0xc2, 0xcd, 0xda, 0xa1, 0xc0, 0x5f, 0x37, 0x3d, 0xe7, 0x54,
+	0x8d, 0xa8, 0x90, 0xef, 0xc1, 0xd2, 0x18, 0xcb, 0x84, 0x0b, 0xb5, 0xab, 0xa2, 0x7b, 0x98, 0x54,
+	0x6d, 0x15, 0x95, 0x70, 0xef, 0xf1, 0x46, 0xf2, 0xba, 0xa4, 0xfc, 0x59, 0x82, 0x92, 0xd8, 0x87,
+	0xae, 0x41, 0xde, 0xcf, 0x0b, 0x27, 0xed, 0xff, 0x68, 0x5a, 0xa8, 0xe6, 0x78, 0x56, 0x48, 0x4c,
+	0xec, 0x58, 0x96, 0x27, 0x58, 0x25, 0xa0, 0xd1, 0xdb, 0x50, 0x7c, 0xc0, 0xb4, 0xdf, 0x20, 0x2b,
+	0xc0, 0xac, 0x32, 0x1e, 0xf3, 0xee, 0x86, 0x3c, 0xaa, 0x28, 0xa0, 0x74, 0xa1, 0x28, 0xf4, 0xcd,
+	0xed, 0x1c, 0x5f, 0xa6, 0x17, 0x56, 0xd6, 0x11, 0x0f, 0x77, 0xd3, 0xa6, 0xc1, 0x18, 0xaf, 0xbc,
+	0x0e, 0x45, 0xe1, 0x1a, 0x86, 0x0c, 0xb4, 0x57, 0xbf, 0x5b, 0x49, 0xc8, 0xb9, 0xcf, 0xbf, 0xbc,
+	0x94, 0xda, 0xc3, 0x0f, 0xc8, 0xd2, 0xab, 0xf5, 0x5a, 0xa3, 0x5e, 0xbb, 0x55, 0x91, 0xe4, 0xe2,
+	0xe7, 0x5f, 0x5e, 0xca, 0xa9, 0x98, 0x56, 0x5c, 0xaf, 0x34, 0xa0, 0x24, 0x9e, 0xd0, 0x28, 0x3c,
+	0x42, 0x50, 0xbe, 0x71, 0xfb, 0x60, 0x77, 0xa7, 0xb6, 0xd9, 0xac, 0x6b, 0x77, 0xf6, 0x9b, 0xf5,
+	0x8a, 0x84, 0x1e, 0x87, 0xe5, 0xdd, 0x9d, 0x9b, 0x8d, 0xa6, 0x56, 0xdb, 0xdd, 0xa9, 0xef, 0x35,
+	0xb5, 0xcd, 0x66, 0x73, 0xb3, 0x76, 0xab, 0x92, 0xdc, 0xf8, 0xae, 0x04, 0x8b, 0x9b, 0x5b, 0xb5,
+	0x1d, 0x02, 0xed, 0x8c, 0xb6, 0xce, 0x2b, 0xda, 0x69, 0x5a, 0x39, 0x9a, 0xfa, 0x62, 0x46, 0x9e,
+	0x5e, 0xd0, 0x47, 0xdb, 0x90, 0xa1, 0x45, 0x25, 0x34, 0xfd, 0x09, 0x8d, 0x3c, 0xa3, 0xc2, 0x4f,
+	0x7e, 0x86, 0xba, 0xca, 0xa9, 0x6f, 0x6a, 0xe4, 0xe9, 0x05, 0x7f, 0xa4, 0x42, 0x21, 0xac, 0x0a,
+	0xcd, 0x7e, 0x63, 0x23, 0xcf, 0x71, 0x09, 0x40, 0x74, 0x86, 0x39, 0xef, 0xec, 0x37, 0x27, 0xf2,
+	0x1c, 0xc1, 0x0c, 0xed, 0x42, 0xce, 0xaf, 0x26, 0xcc, 0x7a, 0x05, 0x23, 0xcf, 0x2c, 0xd0, 0x93,
+	0x25, 0x60, 0x55, 0x9f, 0xe9, 0x4f, 0x7a, 0xe4, 0x19, 0xb7, 0x0d, 0x68, 0x07, 0xb2, 0x3c, 0x91,
+	0x9b, 0xf1, 0xb2, 0x45, 0x9e, 0x55, 0x70, 0x27, 0x46, 0x0b, 0xcb, 0x69, 0xb3, 0x1f, 0x2a, 0xc9,
+	0x73, 0x5c, 0xa4, 0xa0, 0xdb, 0x00, 0x42, 0x8d, 0x67, 0x8e, 0x17, 0x48, 0xf2, 0x3c, 0x17, 0x24,
+	0x68, 0x1f, 0xf2, 0x41, 0x2e, 0x3f, 0xf3, 0x3d, 0x90, 0x3c, 0xfb, 0xa6, 0x02, 0xdd, 0x83, 0x85,
+	0x68, 0x12, 0x3b, 0xdf, 0x2b, 0x1f, 0x79, 0xce, 0x2b, 0x08, 0xa2, 0x3f, 0x9a, 0xd1, 0xce, 0xf7,
+	0xea, 0x47, 0x9e, 0xf3, 0x46, 0x02, 0x7d, 0x02, 0x4b, 0xe3, 0x19, 0xe7, 0xfc, 0x8f, 0x80, 0xe4,
+	0x33, 0xdc, 0x51, 0xa0, 0x01, 0xa0, 0x09, 0x99, 0xea, 0x19, 0xde, 0x04, 0xc9, 0x67, 0xb9, 0xb2,
+	0x20, 0x5b, 0x48, 0x48, 0xff, 0xe6, 0x78, 0x22, 0x24, 0xcf, 0x73, 0x71, 0x41, 0x66, 0x31, 0x21,
+	0x49, 0x3c, 0xc3, 0x8b, 0x21, 0xf9, 0x2c, 0xd7, 0x19, 0xe8, 0x0f, 0x12, 0xac, 0xce, 0xca, 0x1c,
+	0x1f, 0xf5, 0xf9, 0x90, 0xfc, 0xc8, 0xf7, 0x1c, 0x5b, 0xf5, 0xaf, 0xbf, 0x5f, 0x91, 0xbe, 0xf9,
+	0x7e, 0x45, 0xfa, 0xee, 0xfb, 0x15, 0xe9, 0x8b, 0x87, 0x2b, 0x89, 0x6f, 0x1e, 0xae, 0x24, 0xfe,
+	0xfe, 0x70, 0x25, 0xf1, 0xb3, 0x17, 0xba, 0x86, 0xd7, 0x1b, 0xb6, 0xd6, 0xda, 0xd6, 0x60, 0x5d,
+	0x7c, 0x0d, 0x3a, 0xe9, 0x85, 0x6a, 0x2b, 0x4b, 0x11, 0xe1, 0xd5, 0xff, 0x05, 0x00, 0x00, 0xff,
+	0xff, 0x09, 0x84, 0x00, 0x4f, 0xc1, 0x2a, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -3401,6 +3947,9 @@ type ABCIApplicationClient interface {
 	OfferSnapshot(ctx context.Context, in *RequestOfferSnapshot, opts ...grpc.CallOption) (*ResponseOfferSnapshot, error)
 	LoadSnapshotChunk(ctx context.Context, in *RequestLoadSnapshotChunk, opts ...grpc.CallOption) (*ResponseLoadSnapshotChunk, error)
 	ApplySnapshotChunk(ctx context.Context, in *RequestApplySnapshotChunk, opts ...grpc.CallOption) (*ResponseApplySnapshotChunk, error)
+	GetAppHash(ctx context.Context, in *RequestGetAppHash, opts ...grpc.CallOption) (*ResponseGetAppHash, error)
+	GenerateFraudProof(ctx context.Context, in *RequestGenerateFraudProof, opts ...grpc.CallOption) (*ResponseGenerateFraudProof, error)
+	TriggerFraudProofGenerationMode(ctx context.Context, in *RequestTriggerFraudProofGenerationMode, opts ...grpc.CallOption) (*ResponseTriggerFraudProofGenerationMode, error)
 }
 
 type aBCIApplicationClient struct {
@@ -3546,6 +4095,33 @@ func (c *aBCIApplicationClient) ApplySnapshotChunk(ctx context.Context, in *Requ
 	return out, nil
 }
 
+func (c *aBCIApplicationClient) GetAppHash(ctx context.Context, in *RequestGetAppHash, opts ...grpc.CallOption) (*ResponseGetAppHash, error) {
+	out := new(ResponseGetAppHash)
+	err := c.cc.Invoke(ctx, "/tendermint.abci.ABCIApplication/GetAppHash", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *aBCIApplicationClient) GenerateFraudProof(ctx context.Context, in *RequestGenerateFraudProof, opts ...grpc.CallOption) (*ResponseGenerateFraudProof, error) {
+	out := new(ResponseGenerateFraudProof)
+	err := c.cc.Invoke(ctx, "/tendermint.abci.ABCIApplication/GenerateFraudProof", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *aBCIApplicationClient) TriggerFraudProofGenerationMode(ctx context.Context, in *RequestTriggerFraudProofGenerationMode, opts ...grpc.CallOption) (*ResponseTriggerFraudProofGenerationMode, error) {
+	out := new(ResponseTriggerFraudProofGenerationMode)
+	err := c.cc.Invoke(ctx, "/tendermint.abci.ABCIApplication/TriggerFraudProofGenerationMode", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ABCIApplicationServer is the server API for ABCIApplication service.
 type ABCIApplicationServer interface {
 	Echo(context.Context, *RequestEcho) (*ResponseEcho, error)
@@ -3563,6 +4139,9 @@ type ABCIApplicationServer interface {
 	OfferSnapshot(context.Context, *RequestOfferSnapshot) (*ResponseOfferSnapshot, error)
 	LoadSnapshotChunk(context.Context, *RequestLoadSnapshotChunk) (*ResponseLoadSnapshotChunk, error)
 	ApplySnapshotChunk(context.Context, *RequestApplySnapshotChunk) (*ResponseApplySnapshotChunk, error)
+	GetAppHash(context.Context, *RequestGetAppHash) (*ResponseGetAppHash, error)
+	GenerateFraudProof(context.Context, *RequestGenerateFraudProof) (*ResponseGenerateFraudProof, error)
+	TriggerFraudProofGenerationMode(context.Context, *RequestTriggerFraudProofGenerationMode) (*ResponseTriggerFraudProofGenerationMode, error)
 }
 
 // UnimplementedABCIApplicationServer can be embedded to have forward compatible implementations.
@@ -3613,6 +4192,15 @@ func (*UnimplementedABCIApplicationServer) LoadSnapshotChunk(ctx context.Context
 }
 func (*UnimplementedABCIApplicationServer) ApplySnapshotChunk(ctx context.Context, req *RequestApplySnapshotChunk) (*ResponseApplySnapshotChunk, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ApplySnapshotChunk not implemented")
+}
+func (*UnimplementedABCIApplicationServer) GetAppHash(ctx context.Context, req *RequestGetAppHash) (*ResponseGetAppHash, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetAppHash not implemented")
+}
+func (*UnimplementedABCIApplicationServer) GenerateFraudProof(ctx context.Context, req *RequestGenerateFraudProof) (*ResponseGenerateFraudProof, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GenerateFraudProof not implemented")
+}
+func (*UnimplementedABCIApplicationServer) TriggerFraudProofGenerationMode(ctx context.Context, req *RequestTriggerFraudProofGenerationMode) (*ResponseTriggerFraudProofGenerationMode, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TriggerFraudProofGenerationMode not implemented")
 }
 
 func RegisterABCIApplicationServer(s *grpc.Server, srv ABCIApplicationServer) {
@@ -3889,6 +4477,60 @@ func _ABCIApplication_ApplySnapshotChunk_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ABCIApplication_GetAppHash_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RequestGetAppHash)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ABCIApplicationServer).GetAppHash(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tendermint.abci.ABCIApplication/GetAppHash",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABCIApplicationServer).GetAppHash(ctx, req.(*RequestGetAppHash))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ABCIApplication_GenerateFraudProof_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RequestGenerateFraudProof)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ABCIApplicationServer).GenerateFraudProof(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tendermint.abci.ABCIApplication/GenerateFraudProof",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABCIApplicationServer).GenerateFraudProof(ctx, req.(*RequestGenerateFraudProof))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ABCIApplication_TriggerFraudProofGenerationMode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RequestTriggerFraudProofGenerationMode)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ABCIApplicationServer).TriggerFraudProofGenerationMode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tendermint.abci.ABCIApplication/TriggerFraudProofGenerationMode",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABCIApplicationServer).TriggerFraudProofGenerationMode(ctx, req.(*RequestTriggerFraudProofGenerationMode))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _ABCIApplication_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "tendermint.abci.ABCIApplication",
 	HandlerType: (*ABCIApplicationServer)(nil),
@@ -3952,6 +4594,18 @@ var _ABCIApplication_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ApplySnapshotChunk",
 			Handler:    _ABCIApplication_ApplySnapshotChunk_Handler,
+		},
+		{
+			MethodName: "GetAppHash",
+			Handler:    _ABCIApplication_GetAppHash_Handler,
+		},
+		{
+			MethodName: "GenerateFraudProof",
+			Handler:    _ABCIApplication_GenerateFraudProof_Handler,
+		},
+		{
+			MethodName: "TriggerFraudProofGenerationMode",
+			Handler:    _ABCIApplication_TriggerFraudProofGenerationMode_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -4305,6 +4959,75 @@ func (m *Request_ApplySnapshotChunk) MarshalToSizedBuffer(dAtA []byte) (int, err
 	}
 	return len(dAtA) - i, nil
 }
+func (m *Request_GetAppHash) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Request_GetAppHash) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.GetAppHash != nil {
+		{
+			size, err := m.GetAppHash.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Request_GenerateFraudProof) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Request_GenerateFraudProof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.GenerateFraudProof != nil {
+		{
+			size, err := m.GenerateFraudProof.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Request_TriggerFraudProofGenerationMode) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Request_TriggerFraudProofGenerationMode) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.TriggerFraudProofGenerationMode != nil {
+		{
+			size, err := m.TriggerFraudProofGenerationMode.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	return len(dAtA) - i, nil
+}
 func (m *RequestEcho) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -4500,12 +5223,12 @@ func (m *RequestInitChain) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x12
 	}
-	n17, err17 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.Time):])
-	if err17 != nil {
-		return 0, err17
+	n20, err20 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.Time):])
+	if err20 != nil {
+		return 0, err20
 	}
-	i -= n17
-	i = encodeVarintTypes(dAtA, i, uint64(n17))
+	i -= n20
+	i = encodeVarintTypes(dAtA, i, uint64(n20))
 	i--
 	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
@@ -4888,6 +5611,75 @@ func (m *RequestApplySnapshotChunk) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
+func (m *RequestGetAppHash) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RequestGetAppHash) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestGetAppHash) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *RequestGenerateFraudProof) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RequestGenerateFraudProof) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestGenerateFraudProof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *RequestTriggerFraudProofGenerationMode) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RequestTriggerFraudProofGenerationMode) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RequestTriggerFraudProofGenerationMode) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func (m *Response) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -5255,6 +6047,75 @@ func (m *Response_ApplySnapshotChunk) MarshalToSizedBuffer(dAtA []byte) (int, er
 		dAtA[i] = 0x1
 		i--
 		dAtA[i] = 0x82
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Response_GetAppHash) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Response_GetAppHash) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.GetAppHash != nil {
+		{
+			size, err := m.GetAppHash.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Response_GenerateFraudProof) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Response_GenerateFraudProof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.GenerateFraudProof != nil {
+		{
+			size, err := m.GenerateFraudProof.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	return len(dAtA) - i, nil
+}
+func (m *Response_TriggerFraudProofGenerationMode) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Response_TriggerFraudProofGenerationMode) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.TriggerFraudProofGenerationMode != nil {
+		{
+			size, err := m.TriggerFraudProofGenerationMode.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
 	}
 	return len(dAtA) - i, nil
 }
@@ -5998,25 +6859,123 @@ func (m *ResponseApplySnapshotChunk) MarshalToSizedBuffer(dAtA []byte) (int, err
 		}
 	}
 	if len(m.RefetchChunks) > 0 {
-		dAtA41 := make([]byte, len(m.RefetchChunks)*10)
-		var j40 int
+		dAtA47 := make([]byte, len(m.RefetchChunks)*10)
+		var j46 int
 		for _, num := range m.RefetchChunks {
 			for num >= 1<<7 {
-				dAtA41[j40] = uint8(uint64(num)&0x7f | 0x80)
+				dAtA47[j46] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
-				j40++
+				j46++
 			}
-			dAtA41[j40] = uint8(num)
-			j40++
+			dAtA47[j46] = uint8(num)
+			j46++
 		}
-		i -= j40
-		copy(dAtA[i:], dAtA41[:j40])
-		i = encodeVarintTypes(dAtA, i, uint64(j40))
+		i -= j46
+		copy(dAtA[i:], dAtA47[:j46])
+		i = encodeVarintTypes(dAtA, i, uint64(j46))
 		i--
 		dAtA[i] = 0x12
 	}
 	if m.Result != 0 {
 		i = encodeVarintTypes(dAtA, i, uint64(m.Result))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ResponseGetAppHash) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResponseGetAppHash) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ResponseGetAppHash) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.AppHash) > 0 {
+		i -= len(m.AppHash)
+		copy(dAtA[i:], m.AppHash)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.AppHash)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ResponseGenerateFraudProof) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResponseGenerateFraudProof) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ResponseGenerateFraudProof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.FraudProof != nil {
+		{
+			size, err := m.FraudProof.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ResponseTriggerFraudProofGenerationMode) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResponseTriggerFraudProofGenerationMode) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ResponseTriggerFraudProofGenerationMode) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Success {
+		i--
+		if m.Success {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
 		i--
 		dAtA[i] = 0x8
 	}
@@ -6451,12 +7410,12 @@ func (m *Evidence) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x28
 	}
-	n49, err49 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.Time):])
-	if err49 != nil {
-		return 0, err49
+	n56, err56 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Time, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.Time):])
+	if err56 != nil {
+		return 0, err56
 	}
-	i -= n49
-	i = encodeVarintTypes(dAtA, i, uint64(n49))
+	i -= n56
+	i = encodeVarintTypes(dAtA, i, uint64(n56))
 	i--
 	dAtA[i] = 0x22
 	if m.Height != 0 {
@@ -6530,6 +7489,172 @@ func (m *Snapshot) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i = encodeVarintTypes(dAtA, i, uint64(m.Height))
 		i--
 		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *FraudProof) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *FraudProof) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *FraudProof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.StateWitness) > 0 {
+		for k := range m.StateWitness {
+			v := m.StateWitness[k]
+			baseI := i
+			if v != nil {
+				{
+					size, err := v.MarshalToSizedBuffer(dAtA[:i])
+					if err != nil {
+						return 0, err
+					}
+					i -= size
+					i = encodeVarintTypes(dAtA, i, uint64(size))
+				}
+				i--
+				dAtA[i] = 0x12
+			}
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintTypes(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintTypes(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.AppHash) > 0 {
+		i -= len(m.AppHash)
+		copy(dAtA[i:], m.AppHash)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.AppHash)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.BlockHeight != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.BlockHeight))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StateWitness) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StateWitness) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StateWitness) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.WitnessData) > 0 {
+		for iNdEx := len(m.WitnessData) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.WitnessData[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTypes(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.RootHash) > 0 {
+		i -= len(m.RootHash)
+		copy(dAtA[i:], m.RootHash)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.RootHash)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.ProofOp != nil {
+		{
+			size, err := m.ProofOp.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *WitnessData) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *WitnessData) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *WitnessData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Proof != nil {
+		{
+			size, err := m.Proof.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintTypes(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -6734,6 +7859,42 @@ func (m *Request_ApplySnapshotChunk) Size() (n int) {
 	if m.ApplySnapshotChunk != nil {
 		l = m.ApplySnapshotChunk.Size()
 		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Request_GetAppHash) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.GetAppHash != nil {
+		l = m.GetAppHash.Size()
+		n += 2 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Request_GenerateFraudProof) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.GenerateFraudProof != nil {
+		l = m.GenerateFraudProof.Size()
+		n += 2 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Request_TriggerFraudProofGenerationMode) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.TriggerFraudProofGenerationMode != nil {
+		l = m.TriggerFraudProofGenerationMode.Size()
+		n += 2 + l + sovTypes(uint64(l))
 	}
 	return n
 }
@@ -6987,6 +8148,33 @@ func (m *RequestApplySnapshotChunk) Size() (n int) {
 	return n
 }
 
+func (m *RequestGetAppHash) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *RequestGenerateFraudProof) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *RequestTriggerFraudProofGenerationMode) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
 func (m *Response) Size() (n int) {
 	if m == nil {
 		return 0
@@ -7187,6 +8375,42 @@ func (m *Response_ApplySnapshotChunk) Size() (n int) {
 	_ = l
 	if m.ApplySnapshotChunk != nil {
 		l = m.ApplySnapshotChunk.Size()
+		n += 2 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Response_GetAppHash) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.GetAppHash != nil {
+		l = m.GetAppHash.Size()
+		n += 2 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Response_GenerateFraudProof) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.GenerateFraudProof != nil {
+		l = m.GenerateFraudProof.Size()
+		n += 2 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+func (m *Response_TriggerFraudProofGenerationMode) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.TriggerFraudProofGenerationMode != nil {
+		l = m.TriggerFraudProofGenerationMode.Size()
 		n += 2 + l + sovTypes(uint64(l))
 	}
 	return n
@@ -7539,6 +8763,44 @@ func (m *ResponseApplySnapshotChunk) Size() (n int) {
 	return n
 }
 
+func (m *ResponseGetAppHash) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.AppHash)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+
+func (m *ResponseGenerateFraudProof) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.FraudProof != nil {
+		l = m.FraudProof.Size()
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+
+func (m *ResponseTriggerFraudProofGenerationMode) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Success {
+		n += 2
+	}
+	return n
+}
+
 func (m *ConsensusParams) Size() (n int) {
 	if m == nil {
 		return 0
@@ -7744,6 +9006,79 @@ func (m *Snapshot) Size() (n int) {
 	}
 	l = len(m.Metadata)
 	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	return n
+}
+
+func (m *FraudProof) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BlockHeight != 0 {
+		n += 1 + sovTypes(uint64(m.BlockHeight))
+	}
+	l = len(m.AppHash)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	if len(m.StateWitness) > 0 {
+		for k, v := range m.StateWitness {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				l = v.Size()
+				l += 1 + sovTypes(uint64(l))
+			}
+			mapEntrySize := 1 + len(k) + sovTypes(uint64(len(k))) + l
+			n += mapEntrySize + 1 + sovTypes(uint64(mapEntrySize))
+		}
+	}
+	return n
+}
+
+func (m *StateWitness) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ProofOp != nil {
+		l = m.ProofOp.Size()
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	l = len(m.RootHash)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	if len(m.WitnessData) > 0 {
+		for _, e := range m.WitnessData {
+			l = e.Size()
+			n += 1 + l + sovTypes(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *WitnessData) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Key)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	if m.Proof != nil {
+		l = m.Proof.Size()
 		n += 1 + l + sovTypes(uint64(l))
 	}
 	return n
@@ -8308,6 +9643,111 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			m.Value = &Request_ApplySnapshotChunk{v}
+			iNdEx = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GetAppHash", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &RequestGetAppHash{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Value = &Request_GetAppHash{v}
+			iNdEx = postIndex
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GenerateFraudProof", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &RequestGenerateFraudProof{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Value = &Request_GenerateFraudProof{v}
+			iNdEx = postIndex
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TriggerFraudProofGenerationMode", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &RequestTriggerFraudProofGenerationMode{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Value = &Request_TriggerFraudProofGenerationMode{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -9991,6 +11431,156 @@ func (m *RequestApplySnapshotChunk) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *RequestGetAppHash) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RequestGetAppHash: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RequestGetAppHash: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RequestGenerateFraudProof) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RequestGenerateFraudProof: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RequestGenerateFraudProof: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RequestTriggerFraudProofGenerationMode) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RequestTriggerFraudProofGenerationMode: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RequestTriggerFraudProofGenerationMode: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *Response) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -10579,6 +12169,111 @@ func (m *Response) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			m.Value = &Response_ApplySnapshotChunk{v}
+			iNdEx = postIndex
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GetAppHash", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &ResponseGetAppHash{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Value = &Response_GetAppHash{v}
+			iNdEx = postIndex
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field GenerateFraudProof", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &ResponseGenerateFraudProof{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Value = &Response_GenerateFraudProof{v}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TriggerFraudProofGenerationMode", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &ResponseTriggerFraudProofGenerationMode{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Value = &Response_TriggerFraudProofGenerationMode{v}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -12892,6 +14587,246 @@ func (m *ResponseApplySnapshotChunk) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *ResponseGetAppHash) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResponseGetAppHash: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResponseGetAppHash: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AppHash", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AppHash = append(m.AppHash[:0], dAtA[iNdEx:postIndex]...)
+			if m.AppHash == nil {
+				m.AppHash = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ResponseGenerateFraudProof) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResponseGenerateFraudProof: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResponseGenerateFraudProof: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FraudProof", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.FraudProof == nil {
+				m.FraudProof = &FraudProof{}
+			}
+			if err := m.FraudProof.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ResponseTriggerFraudProofGenerationMode) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResponseTriggerFraudProofGenerationMode: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResponseTriggerFraudProofGenerationMode: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Success", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Success = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *ConsensusParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -14319,6 +16254,546 @@ func (m *Snapshot) Unmarshal(dAtA []byte) error {
 			m.Metadata = append(m.Metadata[:0], dAtA[iNdEx:postIndex]...)
 			if m.Metadata == nil {
 				m.Metadata = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *FraudProof) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: FraudProof: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: FraudProof: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+			}
+			m.BlockHeight = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BlockHeight |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AppHash", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AppHash = append(m.AppHash[:0], dAtA[iNdEx:postIndex]...)
+			if m.AppHash == nil {
+				m.AppHash = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StateWitness", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.StateWitness == nil {
+				m.StateWitness = make(map[string]*StateWitness)
+			}
+			var mapkey string
+			var mapvalue *StateWitness
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowTypes
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowTypes
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return ErrInvalidLengthTypes
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &StateWitness{}
+					if err := mapvalue.Unmarshal(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipTypes(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthTypes
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.StateWitness[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StateWitness) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StateWitness: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StateWitness: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProofOp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ProofOp == nil {
+				m.ProofOp = &crypto.ProofOp{}
+			}
+			if err := m.ProofOp.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RootHash", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RootHash = append(m.RootHash[:0], dAtA[iNdEx:postIndex]...)
+			if m.RootHash == nil {
+				m.RootHash = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WitnessData", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.WitnessData = append(m.WitnessData, &WitnessData{})
+			if err := m.WitnessData[len(m.WitnessData)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *WitnessData) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: WitnessData: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: WitnessData: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = append(m.Key[:0], dAtA[iNdEx:postIndex]...)
+			if m.Key == nil {
+				m.Key = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = append(m.Value[:0], dAtA[iNdEx:postIndex]...)
+			if m.Value == nil {
+				m.Value = []byte{}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Proof", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Proof == nil {
+				m.Proof = &crypto.ProofOp{}
+			}
+			if err := m.Proof.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		default:

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -36,6 +36,9 @@ message Request {
     RequestOfferSnapshot      offer_snapshot       = 13;
     RequestLoadSnapshotChunk  load_snapshot_chunk  = 14;
     RequestApplySnapshotChunk apply_snapshot_chunk = 15;
+    RequestGetAppHash         get_app_hash         = 16;
+    RequestGenerateFraudProof generate_fraud_proof = 17;
+    RequestTriggerFraudProofGenerationMode trigger_fraud_proof_generation_mode = 18;
   }
 }
 
@@ -125,6 +128,15 @@ message RequestApplySnapshotChunk {
   string sender = 3;
 }
 
+// Gets the current appHash
+message RequestGetAppHash {}
+
+// Generates a fraud proof
+message RequestGenerateFraudProof {}
+
+// Triggers fraud proof generation mode
+message RequestTriggerFraudProofGenerationMode {}
+
 //----------------------------------------
 // Response types
 
@@ -146,6 +158,9 @@ message Response {
     ResponseOfferSnapshot      offer_snapshot       = 14;
     ResponseLoadSnapshotChunk  load_snapshot_chunk  = 15;
     ResponseApplySnapshotChunk apply_snapshot_chunk = 16;
+    ResponseGetAppHash         get_app_hash         = 17;
+    ResponseGenerateFraudProof generate_fraud_proof = 18;
+    ResponseTriggerFraudProofGenerationMode trigger_fraud_proof_generation_mode = 19;
   }
 }
 
@@ -276,6 +291,18 @@ message ResponseApplySnapshotChunk {
   }
 }
 
+message ResponseGetAppHash {
+  bytes app_hash = 1;
+}
+
+message ResponseGenerateFraudProof {
+  FraudProof fraudProof = 1;
+}
+
+message ResponseTriggerFraudProofGenerationMode {
+  bool success = 1;
+}
+
 //----------------------------------------
 // Misc.
 
@@ -385,6 +412,30 @@ message Snapshot {
   bytes  metadata = 5;  // Arbitrary application metadata
 }
 
+// Represents a single-round fraudProof
+message FraudProof {
+  int64 block_height = 1;
+  bytes appHash = 2;
+  map<string, StateWitness> stateWitness = 3;
+}
+
+// State witness with a list of all witness data
+message StateWitness {
+  // store level proof
+  tendermint.crypto.ProofOp proof_op = 1;
+  // substore level hash
+  bytes rootHash = 2;
+  // List of witness data
+  repeated WitnessData witnessData = 3;
+}
+
+// Witness data containing a key/value pair and a SMT proof for said key/value pair
+message WitnessData {
+  bytes key = 1;
+  bytes value = 2;
+  tendermint.crypto.ProofOp proof = 3;
+}
+
 //----------------------------------------
 // Service Definition
 
@@ -404,4 +455,7 @@ service ABCIApplication {
   rpc OfferSnapshot(RequestOfferSnapshot) returns (ResponseOfferSnapshot);
   rpc LoadSnapshotChunk(RequestLoadSnapshotChunk) returns (ResponseLoadSnapshotChunk);
   rpc ApplySnapshotChunk(RequestApplySnapshotChunk) returns (ResponseApplySnapshotChunk);
+  rpc GetAppHash(RequestGetAppHash) returns (ResponseGetAppHash);
+  rpc GenerateFraudProof(RequestGenerateFraudProof) returns (ResponseGenerateFraudProof);
+  rpc TriggerFraudProofGenerationMode(RequestTriggerFraudProofGenerationMode) returns (ResponseTriggerFraudProofGenerationMode);
 }

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -20,6 +20,9 @@ type AppConnConsensus interface {
 	DeliverTxAsync(types.RequestDeliverTx) *abcicli.ReqRes
 	EndBlockSync(types.RequestEndBlock) (*types.ResponseEndBlock, error)
 	CommitSync() (*types.ResponseCommit, error)
+	GetAppHashSync(types.RequestGetAppHash) (*types.ResponseGetAppHash, error)
+	GenerateFraudProofSync(types.RequestGenerateFraudProof) (*types.ResponseGenerateFraudProof, error)
+	TriggerFraudProofGenerationModeSync(types.RequestTriggerFraudProofGenerationMode) (*types.ResponseTriggerFraudProofGenerationMode, error)
 }
 
 type AppConnMempool interface {
@@ -91,6 +94,18 @@ func (app *appConnConsensus) EndBlockSync(req types.RequestEndBlock) (*types.Res
 
 func (app *appConnConsensus) CommitSync() (*types.ResponseCommit, error) {
 	return app.appConn.CommitSync()
+}
+
+func (app *appConnConsensus) GetAppHashSync(req types.RequestGetAppHash) (*types.ResponseGetAppHash, error) {
+	return app.appConn.GetAppHashSync(req)
+}
+
+func (app *appConnConsensus) GenerateFraudProofSync(req types.RequestGenerateFraudProof) (*types.ResponseGenerateFraudProof, error) {
+	return app.appConn.GenerateFraudProofSync(req)
+}
+
+func (app *appConnConsensus) TriggerFraudProofGenerationModeSync(req types.RequestTriggerFraudProofGenerationMode) (*types.ResponseTriggerFraudProofGenerationMode, error) {
+	return app.appConn.TriggerFraudProofGenerationModeSync(req)
 }
 
 //------------------------------------------------


### PR DESCRIPTION
Adds the following methods required for fraudproof generation to the ABCI interface:
1. `GetAppHash () -> appHash`
2. `TriggerFraudProofGenerationMode () -> ModeEnabledSuccess`
3. `GenerateFraudProof () -> FraudProof`

Fraud Proof type described in https://github.com/celestiaorg/cosmos-sdk/pull/248

Closes: #4 